### PR TITLE
refactor: add shopId to defaultNavitgationTree code to match updates to api

### DIFF
--- a/imports/plugins/core/navigation/client/hocs/defaultNavigationTreeQuery.js
+++ b/imports/plugins/core/navigation/client/hocs/defaultNavigationTreeQuery.js
@@ -2,8 +2,8 @@ import gql from "graphql-tag";
 import { navigationTreeWith10LevelsFragment } from "./fragments";
 
 export default gql`
-  query defaultNavigationTreeQuery($id: ID!, $language: String!) {
-    navigationTreeById(id: $id, language: $language) {
+  query defaultNavigationTreeQuery($id: ID!, $language: String!, shopId: ID!) {
+    navigationTreeById(id: $id, language: $language, shopId: $shopId) {
       ...NavigationTreeWith10Levels
     }
   }

--- a/imports/plugins/core/navigation/client/hocs/withDefaultNavigationTree.js
+++ b/imports/plugins/core/navigation/client/hocs/withDefaultNavigationTree.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Query } from "react-apollo";
+import { Reaction } from "/client/api";
 import defaultNavigationTreeQuery from "./defaultNavigationTreeQuery";
 
 export default (Component) => (
@@ -30,7 +31,8 @@ export default (Component) => (
 
       const variables = {
         id: defaultNavigationTreeId,
-        language: "en"
+        language: "en",
+        shopId: Reaction.getShopId()
       };
 
       return (


### PR DESCRIPTION
[Blocked until https://github.com/reactioncommerce/reaction/pull/5724 is merged]

Impact: **minor**  
Type: **refactor**

## Issue
https://github.com/reactioncommerce/reaction/pull/5724 adds `shopId` to some GQL queries. This PR adds `shopId` to the `admin` to match these queries.

## Breaking changes
None

## Testing
1. See that navigation related admin loads correctly