### PR TITLE
fix: gql query param

### DIFF
--- a/imports/plugins/core/navigation/client/hocs/defaultNavigationTreeQuery.js
+++ b/imports/plugins/core/navigation/client/hocs/defaultNavigationTreeQuery.js
@@ -2,7 +2,7 @@ import gql from "graphql-tag";
 import { navigationTreeWith10LevelsFragment } from "./fragments";
 
 export default gql`
-  query defaultNavigationTreeQuery($id: ID!, $language: String!, shopId: ID!) {
+  query defaultNavigationTreeQuery($id: ID!, $language: String!, $shopId: ID!) {
     navigationTreeById(id: $id, language: $language, shopId: $shopId) {
       ...NavigationTreeWith10Levels
     }


### PR DESCRIPTION
Impact: **critical**  
Type: **bugfix**

## Issue

Query missing `$` in front of `shopId`

## Solution

Add the `$`

## Testing
1. Ensure the app starts and the Navigation admin loads. (you cannot save it, that's another issue that's already been logged)