### PR TITLE
chore: fix Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR $APP_SOURCE_DIR
 USER node
 
 # Ensure we have a config file
-RUN if [[ ! -f "config.js" ]]; then cp config.example.js config.js; fi
+RUN if [ ! -f "config.js" ]; then cp config.example.js config.js; fi
 
 RUN npm install --no-audit
 RUN printf "\\n[-] Building Meteor application...\\n" \


### PR DESCRIPTION
BLOCKED Need to merge #87 updating the app to Meteor 1.8.1 first.

This should fix the `reactioncommerce/admin` Docker image that is built and pushed to DockerHub when this is merged to `trunk`.

**One fix**: Before building, copies `config.example.js` to `config.js` if `config.js` isn't there.

**One optimizatio**n: start the build from `reactioncommerce/meteor:1.8.1-v1` image, which already has the correct version of Node and Meteor installed