### PR TITLE
refactor: remove UI to set Stripe API settings

### DIFF
--- a/imports/plugins/included/payments-stripe/client/settings/stripe.html
+++ b/imports/plugins/included/payments-stripe/client/settings/stripe.html
@@ -1,58 +1,8 @@
 <template name="stripeSettings">
-  {{#unless packageData.settings.api_key}}
-  <div class="alert alert-info">
-    <span data-i18n="admin.paymentSettings.stripeSettingsDescription">Don't have a Stripe API Secret Key?</span>
-    <a href="https://dashboard.stripe.com/account/apikeys" target="_blank">
-      <span data-i18n="admin.paymentSettings.stripeSettingsGetItHere">Get it here.</span>
-    </a>
-  </div>
-  {{/unless}}
   <div>
     {{#autoForm collection=Collections.Packages schema=StripePackageConfig doc=packageData type="update" id="stripe-update-form"}}
-      {{>afQuickField name='settings.api_key'}}
-      {{>afQuickField name='settings.public.publishable_key'}}
-      <button type="submit" class="btn btn-primary pull-right"><span data-i18n="app.saveChanges">Save Changes</span></button>
+    <button type="submit" class="btn btn-primary pull-right"><span data-i18n="app.saveChanges">Save
+        Changes</span></button>
     {{/autoForm}}
-  </div>
-</template>
-
-<template name="stripe">
-  <div class="container-fluid-sm flex">
-    <div class="flex-item">
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <div class="panel-title">Stripe Checkout</div>
-        </div>
-        <div class="list-group">
-          <div class="list-group-item">
-            {{#if packageData.settings.api_key}}
-              <span>API Secret Key: <button type="button" class="btn btn-link" data-event-action="showStripeSettings">**********</button></span>
-            {{else}}
-              <span>API Secret Key: <button type="button" class="btn btn-link" data-event-action="showStripeSettings">Configure Now</button></span>
-            {{/if}}
-          </div>
-        </div>
-        <div class="panel-footer">
-          <div class="left"></div>
-          <div class="right">
-
-            <div class="panel-footer-item">
-              {{#if packageData.settings.api_key}}
-                <i class="fa fa-check-circle fa-2x text-success"></i>
-              {{else}}
-                <i class="fa fa-minus-circle fa-2x text-muted"></i>
-              {{/if}}
-            </div>
-
-            <div class="panel-footer-item">
-              <button class="btn btn-default" data-event-action="showStripeSettings">
-                <i class="fa fa-gear"></i>
-              </button>
-            </div>
-
-          </div>
-        </div>
-      </div>
-    </div>
   </div>
 </template>

--- a/imports/plugins/included/payments-stripe/client/settings/stripe.js
+++ b/imports/plugins/included/payments-stripe/client/settings/stripe.js
@@ -23,16 +23,6 @@ Template.stripeSettings.helpers({
   packageData
 });
 
-Template.stripe.helpers({
-  packageData
-});
-
-Template.stripe.events({
-  "click [data-event-action=showStripeSettings]"() {
-    Reaction.showActionView();
-  }
-});
-
 AutoForm.hooks({
   "stripe-update-form": {
     onSuccess() {

--- a/imports/plugins/included/payments-stripe/lib/collections/schemas/stripe.js
+++ b/imports/plugins/included/payments-stripe/lib/collections/schemas/stripe.js
@@ -53,10 +53,6 @@ export const StripePackageConfig = PackageConfig.clone().extend({
     type: Boolean,
     defaultValue: false
   },
-  "settings.api_key": {
-    type: String,
-    label: "API Secret Key"
-  },
   // This field only applies to marketplace style orders where a payment is taken on behalf of another store
   "settings.applicationFee": {
     type: Number,
@@ -64,25 +60,9 @@ export const StripePackageConfig = PackageConfig.clone().extend({
     optional: true,
     defaultValue: 5
   },
-  "settings.connectAuth": {
-    type: StripeConnectAuthorizationCredentials,
-    label: "Connect Authorization Credentials",
-    optional: true
-  },
   "settings.public": {
     type: Object,
     defaultValue: {}
-  },
-  // Public Settings
-  "settings.public.client_id": {
-    type: String,
-    label: "Public Client ID",
-    optional: true
-  },
-  "settings.public.publishable_key": {
-    type: String,
-    label: "Publishable Key",
-    optional: true
   }
 });
 


### PR DESCRIPTION
Resolves #85  
Impact: minor 
Type: Refactor

## Issue
Stripe API settings UI is no longer needed.

## Solution
UI removed.

## Testing
1. App start correctly
 2. In "Payments" settings, an admin user should ONLY be able to toggle Stripe on/off
