### PR TITLE
fix: Resolve port conflict with reaction

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       streams:
     ports:
       - "4080:4080"
-      - "9229:9229"
+      - "9231:9229"
     volumes:
       - .:/usr/local/src/app:cached
       - reaction_meteor_local:/usr/local/src/app/.meteor/local


### PR DESCRIPTION
Resolves #issueNumber  
Impact: **minor**  
Type: **bugfix**

## Issue
We were trying to publish the same 9229 port as core reaction. Means you can't run them both at the same time.

## Solution
Use a different port on the host.

## Breaking changes
N/A

## Testing
- start reaction core and reaction admin at the same time