### PR TITLE
chore: use published image for docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ imports/plugins/custom/*
 coverage/*
 
 .reaction/pluginConfig.js
+
+docker-compose.override.yml

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -7,17 +7,16 @@ USER root
 # Every directory that will be listed in `volumes` section of
 # docker-compose.yml needs to be pre-created and chown'd here.
 # See https://github.com/docker/compose/issues/3270#issuecomment-363478501
-RUN mkdir -p /usr/local/src/app/node-modules \
+RUN mkdir -p /usr/local/src/app/node_modules \
   && mkdir -p /usr/local/src/app/.meteor/local \
-  && chown node:node /usr/local/src/app \
-  && chown node:node /usr/local/src/app/node-modules \
-  && chown node:node /usr/local/src/app/.meteor/local
+  && chown node /usr/local/src/app \
+  && chown node /usr/local/src/app/node_modules \
+  && chown node /usr/local/src/app/.meteor/local
 
 WORKDIR /usr/local/src/app
 
 USER node
 
-ENV PATH=$PATH:/usr/local/src/app/node_modules/.bin:/home/node/.meteor \
-  BUILD_ENV=development NODE_ENV=development
+ENV PATH $PATH:/usr/local/src/app/node_modules/.bin:/home/node/.meteor
 
 CMD ["npm", "run", "start:dev"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,34 @@
+# This docker-compose file is used to run the project in Docker for development.
+# The local files are mounted into the created container.
+#
+# Usage:
+#  ln -s docker-compose.dev.yml docker-compose.override.yml
+#  docker-compose up [-d]
+#
+# To go back to running the published image:
+#  rm docker-compose.override.yml
+
+version: '3.4'
+
+services:
+  reaction-admin:
+    # The main `docker-compose.yml` has an `image` prop. Unfortunately, when we
+    # add `build` prop here, it changes the meaning of that `image` prop to
+    # "tag the built image with this image name". This has the effect of breaking
+    # the app after you've run with the override and then go back to running without
+    # it, because now `reactioncommerce/admin:trunk` would actually be your dev image.
+    # To work around this issue, we specify a different tag name here, which does not
+    # match any of our published tags.
+    image: reactioncommerce/admin:local-dev
+    build:
+      context: .
+      dockerfile: Dockerfile-dev
+    command: bash -c "export PATH=$PATH:/home/node/.meteor && time meteor npm install --no-audit && node --experimental-modules ./.reaction/scripts/run.mjs"
+    volumes:
+      - .:/usr/local/src/app:cached
+      - reaction_meteor_local:/usr/local/src/app/.meteor/local
+      - reaction_node_modules:/usr/local/src/app/node_modules # do not link node_modules in, and persist it between dc up runs
+
+volumes:
+  reaction_node_modules:
+  reaction_meteor_local:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
-# This docker-compose file is used to run the reaction app in docker for development
-# The local files are mounted into the created container.
+# This docker-compose file is used to run the project's published image
+#
 # Usage: docker-compose up [-d]
+#
+# See comment in docker-compose.dev.yml if you want to run for development.
 
 version: '3.4'
 
@@ -11,32 +13,23 @@ networks:
   auth:
     external:
       name: auth.reaction.localhost
+  reaction:
+    external:
+      name: reaction.localhost
   streams:
     external:
       name: streams.reaction.localhost
 
 services:
-
   reaction-admin:
-    build:
-      context: .
-      dockerfile: Dockerfile-dev
-    command: bash -c "time meteor npm install --no-audit && node --experimental-modules ./.reaction/scripts/run.mjs"
+    image: reactioncommerce/admin:trunk
     env_file:
       - ./.env
     networks:
-      default:
       api:
       auth:
+      reaction:
       streams:
     ports:
       - "4080:4080"
       - "9231:9229"
-    volumes:
-      - .:/usr/local/src/app:cached
-      - reaction_meteor_local:/usr/local/src/app/.meteor/local
-      - reaction_node_modules:/usr/local/src/app/node_modules # do not link node_modules in, and persist it between dc up runs
-
-volumes:
-  reaction_node_modules:
-  reaction_meteor_local:


### PR DESCRIPTION
Impact: **minor**
Type: **chore**

## Changes
When you clone this branch and run `docker-compose up`, it will now pull and use the latest published `reactioncommerce/admin:trunk` image from DockerHub instead of building an image using `Dockerfile-dev`. Host files are not linked in, NPM deps are not reinstalled, and the built Node app will run instead of the Meteor app.

## Breaking changes
Breaking only for devs who will now need to run `ln -s docker-compose.dev.yml docker-compose.override.yml` to get the previous behavior.

## Testing
- Verify `dc up` starts quickly and in prod mode. (You should not see anything about Meteor in the logs.)
- After `dc down`, run `ln -s docker-compose.dev.yml docker-compose.override.yml` and then `dc up` again. Verify it now starts in dev mode and reloads when you change files.
- After `dc down`, run `rm docker-compose.override.yml` to remove the override file. It should be back to running in prod mode when you do `dc up`.