### PR TITLE
fix: Allow variant fields to be updated on page refresh

### DIFF
--- a/imports/plugins/included/product-admin/client/hocs/withVariantForm.js
+++ b/imports/plugins/included/product-admin/client/hocs/withVariantForm.js
@@ -69,10 +69,6 @@ const wrapComponent = (Comp) => (
         return;
       }
 
-      if (typeof nextProps.variant.isVisible === "boolean") {
-        return;
-      }
-
       if (_.isEqual(nextVariant, currentVariant) === false) {
         this.setState({
           inventoryManagement: nextProps.variant && nextProps.variant.inventoryManagement,
@@ -169,7 +165,7 @@ const wrapComponent = (Comp) => (
       }
     }
 
-    cloneVariant = async (productId, variantId) => {
+    cloneVariant = async (variantId) => {
       const { client, shopId } = this.props;
       const title = i18next.t("productDetailEdit.thisVariant");
       const [opaqueVariantId] = await getOpaqueIds([{ namespace: "Product", id: variantId }]);


### PR DESCRIPTION
Signed-off-by: trojanh <rajan.tiwari@kiprosh.com>

Resolves https://github.com/reactioncommerce/reaction-admin/issues/173
Impact: **breaking|major**  
Type: **bugfix**

## Issue
Refreshing variants page causes all the fields to be reset and throws 400 error because of the null `variantId`.

## Solution
Initialize `variantId` in `UNSAFE_componentWillReceiveProps`


## Breaking changes
none

## Testing
1. Visit product variants page and refresh the page
2. Edit any input field, 
3. Observe that 400 error is thrown and all the inputs get empty

