### PR TITLE
refactor: get `permissions` from groups, not user object

### DIFF
--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -140,7 +140,7 @@ export default {
       // set permissions array with shopId as key on accountPermissions object
       uniqueShopIds.forEach((shopId) => {
         const groupPermissionsForShop = groups.filter((group) => group.shopId === shopId).map((group) => group.permissions);
-        const flattenedGroupPermissionsForShop = groupPermissionsForShop.flat();
+        const flattenedGroupPermissionsForShop = _.flattenDeep(groupPermissionsForShop);
         const uniquePermissionsForShop = _.uniq(flattenedGroupPermissionsForShop);
         accountPermissions[permissionsGroup] = uniquePermissionsForShop;
       });

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -6,7 +6,7 @@ import { Tracker } from "meteor/tracker";
 import { ReactiveVar } from "meteor/reactive-var";
 import { ReactiveDict } from "meteor/reactive-dict";
 import { Roles } from "meteor/alanning:roles";
-import { Shops } from "/lib/collections";
+import { Accounts, Groups, Shops } from "/lib/collections";
 import { Router } from "/client/modules/router";
 import { getUserId } from "./helpers/utils";
 
@@ -105,17 +105,47 @@ export default {
    * @returns {Boolean} Boolean - true if has permission
    */
   hasPermission(checkPermissions, checkUserId, checkGroup) {
-    let group;
-    // default group to the shop or global if shop isn't defined for some reason.
+    let permissionsGroup;
+    // default permissionsGroup to the shop or global if shop isn't defined for some reason.
     if (checkGroup !== undefined && typeof checkGroup === "string") {
-      group = checkGroup;
+      permissionsGroup = checkGroup;
     } else {
-      group = this.getShopId() || Roles.GLOBAL_GROUP;
+      permissionsGroup = this.getShopId() || Roles.GLOBAL_GROUP;
     }
 
     let permissions = ["owner"];
     let id = "";
     const userId = checkUserId || getUserId();
+
+    // Groups that a user belongs to are saved on the `account` object, not the `user` object
+    const account = Accounts.findOne({
+      userId
+    });
+
+    let accountPermissions;
+    if (account && Array.isArray(account.groups)) {
+      const user = Meteor.user();
+      // set __global_roles__ from the user
+      accountPermissions = { __global_permissions__: (user && user.roles && user.roles.__global_roles__) || [] }; // eslint-disable-line camelcase
+
+      // get all groups that this user belongs to
+      const groups = Groups.find({ _id: { $in: account.groups } }).fetch();
+      // get unique shops from groups (there may be multiple groups from one shop)
+      const allShopIds = groups.map((group) => group.shopId);
+      const uniqueShopIds = _.uniq(allShopIds);
+
+      // get all groups for shop
+      // flatten all group arrays into a single array
+      // remove duplicate permissions
+      // set permissions array with shopId as key on accountPermissions object
+      uniqueShopIds.forEach((shopId) => {
+        const groupPermissionsForShop = groups.filter((group) => group.shopId === shopId).map((group) => group.permissions);
+        const flattenedGroupPermissionsForShop = groupPermissionsForShop.flat();
+        const uniquePermissionsForShop = _.uniq(flattenedGroupPermissionsForShop);
+        accountPermissions[permissionsGroup] = uniquePermissionsForShop;
+      });
+    }
+
     //
     // local roleCheck function
     // is the bulk of the logic
@@ -135,6 +165,7 @@ export default {
       } else {
         permissions = checkPermissions;
       }
+
       // if the user has owner permissions we'll always check if those roles are enough
       // By adding the "owner" role to the permissions list, we are making hasPermission always return
       // true for "owners". This gives owners global access.
@@ -142,10 +173,10 @@ export default {
       permissions.push("owner");
       permissions = _.uniq(permissions);
 
-      //
-      // return if user has permissions in the group
-      //
-      if (Roles.userIsInRole(userId, permissions, group)) {
+      // if accountPermissions includes any of checkPermissions, then we return true
+      // (this replaces `Roles.userIsInRole`)
+      const hasPermission = accountPermissions[permissionsGroup].some((permission) => checkPermissions.includes(permission));
+      if (hasPermission) {
         return true;
       }
 

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -175,7 +175,7 @@ export default {
 
       // if accountPermissions includes any of checkPermissions, then we return true
       // (this replaces `Roles.userIsInRole`)
-      return accountPermissions[permissionsGroup].some((permission) => checkPermissions.includes(permission));
+      return accountPermissions[permissionsGroup].some((permission) => permissions.includes(permission));
     }
 
     /**

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -175,13 +175,7 @@ export default {
 
       // if accountPermissions includes any of checkPermissions, then we return true
       // (this replaces `Roles.userIsInRole`)
-      const hasPermission = accountPermissions[permissionsGroup].some((permission) => checkPermissions.includes(permission));
-      if (hasPermission) {
-        return true;
-      }
-
-      // no specific permissions found returning false
-      return false;
+      return accountPermissions[permissionsGroup].some((permission) => checkPermissions.includes(permission));
     }
 
     /**

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -173,7 +173,7 @@ export default {
       permissions.push("owner");
       permissions = _.uniq(permissions);
 
-      // if accountPermissions includes any of checkPermissions, then we return true
+      // if accountPermissions includes any of permissions, then we return true
       // (this replaces `Roles.userIsInRole`)
       return accountPermissions[permissionsGroup].some((permission) => permissions.includes(permission));
     }

--- a/imports/plugins/core/accounts/client/components/groupsTableCell.js
+++ b/imports/plugins/core/accounts/client/components/groupsTableCell.js
@@ -54,7 +54,7 @@ const GroupsTableCell = (props) => {
     const groupName = group.name && _.startCase(group.name);
     const groupNameSpan = <span className="group-dropdown">{groupName}</span>;
     const ownerGroup = groups.find((grp) => grp.slug === "owner") || {};
-    const hasOwnerAccess = Reaction.hasPermission("owner", Reaction.getUserId(), Reaction.getShopId());
+    const hasOwnerAccess = Reaction.hasPermission("reaction:legacy:shops/owner", Reaction.getUserId(), Reaction.getShopId());
 
     // Permission check. Remove owner option, if user is not current owner.
     // Also remove groups user does not have roles to manage. This is also checked on the server

--- a/imports/plugins/core/accounts/server/methods/addUserPermissions.js
+++ b/imports/plugins/core/accounts/server/methods/addUserPermissions.js
@@ -15,7 +15,7 @@ import ReactionError from "@reactioncommerce/reaction-error";
  * @returns {Boolean} success/failure
  */
 export default function addUserPermissions(userId, permissions, group) {
-  if (!Reaction.hasPermission("reaction-accounts", Reaction.getUserId(), group)) {
+  if (!Reaction.hasPermission("reaction:legacy:accounts/invite:group", Reaction.getUserId(), group)) {
     throw new ReactionError("access-denied", "Access denied");
   }
   check(userId, Match.OneOf(String, Array));

--- a/imports/plugins/core/accounts/server/methods/group/createGroup.js
+++ b/imports/plugins/core/accounts/server/methods/group/createGroup.js
@@ -28,7 +28,7 @@ export default function createGroup(groupData, shopId) {
 
   // we are limiting group method actions to only users with admin roles
   // this also include shop owners, since they have the `admin` role in their Roles.GLOBAL_GROUP
-  if (!Reaction.hasPermission("admin", Reaction.getUserId(), shopId)) {
+  if (!Reaction.hasPermission("reaction:legacy:groups/create", Reaction.getUserId(), shopId)) {
     throw new ReactionError("access-denied", "Access Denied");
   }
 

--- a/imports/plugins/core/accounts/server/methods/group/updateGroup.js
+++ b/imports/plugins/core/accounts/server/methods/group/updateGroup.js
@@ -26,7 +26,7 @@ export default function updateGroup(groupId, newGroupData, shopId) {
 
   // we are limiting group method actions to only users with admin roles
   // this also include shop owners, since they have the `admin` role in their Roles.GLOBAL_GROUP
-  if (!Reaction.hasPermission("admin", Reaction.getUserId(), shopId)) {
+  if (!Reaction.hasPermission("reaction:legacy:groups/update", Reaction.getUserId(), shopId)) {
     throw new ReactionError("access-denied", "Access Denied");
   }
 

--- a/imports/plugins/core/accounts/server/methods/removeUserPermissions.js
+++ b/imports/plugins/core/accounts/server/methods/removeUserPermissions.js
@@ -15,7 +15,7 @@ import ReactionError from "@reactioncommerce/reaction-error";
  * @returns {Boolean} success/failure
  */
 export default function removeUserPermissions(userId, permissions, group) {
-  if (!Reaction.hasPermission("reaction-accounts", Reaction.getUserId(), group)) {
+  if (!Reaction.hasPermission("reaction:legacy:accounts/invite:group", Reaction.getUserId(), group)) {
     throw new ReactionError("access-denied", "Access denied");
   }
   check(userId, String);

--- a/imports/plugins/core/accounts/server/methods/setUserPermissions.js
+++ b/imports/plugins/core/accounts/server/methods/setUserPermissions.js
@@ -14,7 +14,7 @@ import ReactionError from "@reactioncommerce/reaction-error";
  * @returns {Boolean} returns Roles.setUserRoles result
  */
 export default function setUserPermissions(userId, permissions, group) {
-  if (!Reaction.hasPermission("reaction-accounts", Reaction.getUserId(), group)) {
+  if (!Reaction.hasPermission("reaction:legacy:accounts/invite:group", Reaction.getUserId(), group)) {
     throw new ReactionError("access-denied", "Access denied");
   }
   check(userId, String);

--- a/imports/plugins/core/catalog/server/methods/catalog.js
+++ b/imports/plugins/core/catalog/server/methods/catalog.js
@@ -134,7 +134,7 @@ Meteor.methods({
       throw new ReactionError("not-found", "Product not found");
     }
 
-    if (!Reaction.hasPermission(["createProduct", "product/admin", "product/update"], this.userId, doc.shopId)) {
+    if (!Reaction.hasPermission(["reaction:legacy:products/update"], this.userId, doc.shopId)) {
       throw new ReactionError("access-denied", "Access Denied");
     }
 
@@ -214,7 +214,7 @@ Meteor.methods({
       throw new ReactionError("not-found", "Product not found");
     }
 
-    if (!Reaction.hasPermission(["createProduct", "product/admin", "product/update"], this.userId, product.shopId)) {
+    if (!Reaction.hasPermission(["reaction:legacy:products/update"], this.userId, product.shopId)) {
       throw new ReactionError("access-denied", "Access Denied");
     }
 
@@ -295,7 +295,7 @@ Meteor.methods({
     const product = Products.findOne(productId);
     if (!product) {
       throw new ReactionError("not-found", "Product not found");
-    } else if (!Reaction.hasPermission(["createProduct", "product/admin", "product/update"], this.userId, product.shopId)) {
+    } else if (!Reaction.hasPermission(["reaction:legacy:products/update"], this.userId, product.shopId)) {
       throw new ReactionError("access-denied", "Access Denied");
     }
 
@@ -330,7 +330,7 @@ Meteor.methods({
     const product = Products.findOne(productId);
     if (!product) {
       throw new ReactionError("not-found", "Product not found");
-    } else if (!Reaction.hasPermission(["createProduct", "product/admin", "product/update"], this.userId, product.shopId)) {
+    } else if (!Reaction.hasPermission(["reaction:legacy:products/update"], this.userId, product.shopId)) {
       throw new ReactionError("access-denied", "Access Denied");
     }
 
@@ -365,7 +365,7 @@ Meteor.methods({
     const product = Products.findOne(productId);
     if (!product) {
       throw new ReactionError("not-found", "Product not found");
-    } else if (!Reaction.hasPermission(["createProduct", "product/admin", "product/update"], this.userId, product.shopId)) {
+    } else if (!Reaction.hasPermission(["reaction:legacy:products/update"], this.userId, product.shopId)) {
       throw new ReactionError("access-denied", "Access Denied");
     }
 
@@ -433,7 +433,7 @@ Meteor.methods({
     // This checks to make sure the user has createProduct permissions for the active shop.
     // TODO: We should determine if that is the correct role that a user should have
     // to be permitted to re-arrange products on the grid
-    if (!Reaction.hasPermission(["createProduct", "product/admin", "product/update"], this.userId, shopId)) {
+    if (!Reaction.hasPermission(["reaction:legacy:products/update"], this.userId, shopId)) {
       throw new ReactionError("access-denied", "Access Denied");
     }
 
@@ -477,7 +477,7 @@ Meteor.methods({
     const product = Products.findOne(productId);
     if (!product) {
       throw new ReactionError("not-found", "Product not found");
-    } else if (!Reaction.hasPermission(["createProduct", "product/admin", "product/update"], this.userId, product.shopId)) {
+    } else if (!Reaction.hasPermission(["reaction:legacy:products/update"], this.userId, product.shopId)) {
       throw new ReactionError("access-denied", "Access Denied");
     }
 
@@ -551,7 +551,7 @@ Meteor.methods({
     const product = Products.findOne(productId);
     if (!product) {
       throw new ReactionError("not-found", "Product not found");
-    } else if (!Reaction.hasPermission(["createProduct", "product/admin", "product/update"], this.userId, product.shopId)) {
+    } else if (!Reaction.hasPermission(["reaction:legacy:products/update"], this.userId, product.shopId)) {
       throw new ReactionError("access-denied", "Access Denied");
     }
 
@@ -585,7 +585,7 @@ Meteor.methods({
       throw new ReactionError("not-found", "Product not found");
     }
 
-    if (!Reaction.hasPermission(["createProduct", "product/admin", "product/update"], this.userId, product.shopId)) {
+    if (!Reaction.hasPermission(["reaction:legacy:products/update"], this.userId, product.shopId)) {
       throw new ReactionError("access-denied", "Access Denied");
     }
 

--- a/imports/plugins/core/core/server/Reaction/core.js
+++ b/imports/plugins/core/core/server/Reaction/core.js
@@ -148,8 +148,7 @@ export default {
 
     // if accountPermissions includes any of checkPermissions, then we return true
     // (this replaces `Roles.userIsInRole`)
-    const hasPermission = accountPermissions[group].some((permission) => checkPermissions.includes(permission));
-    return hasPermission;
+    return accountPermissions[group].some((permission) => checkPermissions.includes(permission));
   },
 
   /**

--- a/imports/plugins/core/core/server/Reaction/core.js
+++ b/imports/plugins/core/core/server/Reaction/core.js
@@ -16,7 +16,7 @@ import { getUserId } from "./accountUtils";
  */
 
 // Unpack the named Collections we use.
-const { Shops, Accounts: AccountsCollection } = Collections;
+const { Groups, Shops, Accounts: AccountsCollection } = Collections;
 
 export default {
   /**
@@ -117,8 +117,39 @@ export default {
     permissions.push("owner");
     permissions = _.uniq(permissions);
 
-    // return if user has permissions in the group
-    return Roles.userIsInRole(userId, permissions, group);
+    // Groups that a user belongs to are saved on the `account` object, not the `user` object
+    const account = AccountsCollection.findOne({
+      userId
+    });
+
+    let accountPermissions;
+    if (account && Array.isArray(account.groups)) {
+      const user = Meteor.user();
+      // set __global_roles__ from the user
+      accountPermissions = { __global_permissions__: (user && user.roles && user.roles.__global_roles__) || [] }; // eslint-disable-line camelcase
+
+      // get all groups that this user belongs to
+      const groups = Groups.find({ _id: { $in: account.groups } }).fetch();
+      // get unique shops from groups (there may be multiple groups from one shop)
+      const allShopIds = groups.map((grp) => grp.shopId);
+      const uniqueShopIds = _.uniq(allShopIds);
+
+      // get all groups for shop
+      // flatten all group arrays into a single array
+      // remove duplicate permissions
+      // set permissions array with shopId as key on accountPermissions object
+      uniqueShopIds.forEach((shopId) => {
+        const groupPermissionsForShop = groups.filter((grp) => grp.shopId === shopId).map((grp) => grp.permissions);
+        const flattenedGroupPermissionsForShop = _.flattenDeep(groupPermissionsForShop);
+        const uniquePermissionsForShop = _.uniq(flattenedGroupPermissionsForShop);
+        accountPermissions[group] = uniquePermissionsForShop;
+      });
+    }
+
+    // if accountPermissions includes any of checkPermissions, then we return true
+    // (this replaces `Roles.userIsInRole`)
+    const hasPermission = accountPermissions[group].some((permission) => checkPermissions.includes(permission));
+    return hasPermission;
   },
 
   /**

--- a/imports/plugins/core/core/server/methods/shop/createTag.js
+++ b/imports/plugins/core/core/server/methods/shop/createTag.js
@@ -21,7 +21,7 @@ export default function createTag(tagName, isTopLevel) {
   check(isTopLevel, Boolean);
 
   // must have 'core' permissions
-  if (!Reaction.hasPermission("core")) {
+  if (!Reaction.hasPermission("reaction:legacy:tags/create")) {
     throw new ReactionError("access-denied", "Access Denied");
   }
 

--- a/imports/plugins/core/core/server/methods/shop/updateBrandAssets.js
+++ b/imports/plugins/core/core/server/methods/shop/updateBrandAssets.js
@@ -22,7 +22,7 @@ function updateShopBrandAssets(asset, shopId = Reaction.getShopId(), userId = Re
   check(shopId, String);
 
   // must have core permissions
-  if (!Reaction.hasPermission("core", userId, shopId)) {
+  if (!Reaction.hasPermission("reaction:legacy:shops/update", userId, shopId)) {
     throw new ReactionError("access-denied", "Access Denied");
   }
 

--- a/imports/plugins/core/core/server/methods/shop/updateCurrencyConfiguration.js
+++ b/imports/plugins/core/core/server/methods/shop/updateCurrencyConfiguration.js
@@ -17,7 +17,7 @@ export default function updateCurrencyConfiguration(currency, enabled) {
   check(enabled, Boolean);
 
   // must have core permissions
-  if (!Reaction.hasPermission("core")) {
+  if (!Reaction.hasPermission("reaction:legacy:shops/update")) {
     throw new ReactionError("access-denied", "Access Denied");
   }
   this.unblock();

--- a/imports/plugins/core/core/server/methods/shop/updateDefaultParcelSize.js
+++ b/imports/plugins/core/core/server/methods/shop/updateDefaultParcelSize.js
@@ -3,7 +3,7 @@ import { Shops } from "/lib/collections";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
 import ReactionError from "@reactioncommerce/reaction-error";
 
-const shippingRoles = ["admin", "owner", "shipping"];
+const shippingRoles = ["reaction:legacy:shippingMethods/update"];
 
 /**
  * @method shop/updateDefaultParcelSize

--- a/imports/plugins/core/core/server/methods/shop/updateHeaderTags.js
+++ b/imports/plugins/core/core/server/methods/shop/updateHeaderTags.js
@@ -26,7 +26,7 @@ export default function updateHeaderTags(tagName, tagId, currentTagId) {
   // Must have 'core' permissions for the current shop ID. We then pass in
   // that shopId to all of the Tags.update calls below to ensure that
   // all of the modified tags belong to this shop.
-  if (!Reaction.hasPermission("core", Reaction.getUserId(), shopId)) {
+  if (!Reaction.hasPermission("reaction:legacy:tags/update", Reaction.getUserId(), shopId)) {
     throw new ReactionError("access-denied", "Access Denied");
   }
   this.unblock();

--- a/imports/plugins/core/core/server/methods/shop/updateLanguageConfiguration.js
+++ b/imports/plugins/core/core/server/methods/shop/updateLanguageConfiguration.js
@@ -16,8 +16,8 @@ export default function updateLanguageConfiguration(language, enabled) {
   check(language, String);
   check(enabled, Boolean);
 
-  // must have core permissions
-  if (!Reaction.hasPermission("core")) {
+  // must have reaction:legacy:shops/update permissions
+  if (!Reaction.hasPermission("reaction:legacy:shops/update")) {
     throw new ReactionError("access-denied", "Access Denied");
   }
   this.unblock();

--- a/imports/plugins/core/core/server/publications/collections/media.js
+++ b/imports/plugins/core/core/server/publications/collections/media.js
@@ -34,7 +34,7 @@ Meteor.publish("ProductGridMedia", function productGridMediaPublish(productIds) 
   // Product editors can see both published and unpublished images
   // There is an implied shopId in Reaction.hasPermission that defaults to
   // the active shopId via Reaction.getShopId
-  if (!Reaction.hasPermission(["createProduct", "product/admin", "product/publish"], this.userId)) {
+  if (!Reaction.hasPermission(["reaction:legacy:products/publish"], this.userId)) {
     selector["metadata.workflow"].$in = [null, "published"];
   }
 
@@ -62,7 +62,7 @@ Meteor.publish("ProductMedia", function productMediaPublish(id) {
   // Product editors can see both published and unpublished images
   // There is an implied shopId in Reaction.hasPermission that defaults to
   // the active shopId via Reaction.getShopId
-  if (!Reaction.hasPermission(["createProduct", "product/admin", "product/publish"], this.userId)) {
+  if (!Reaction.hasPermission(["reaction:legacy:products/publish"], this.userId)) {
     selector["metadata.workflow"].$in = [null, "published"];
   }
 

--- a/imports/plugins/core/core/server/publications/collections/orders.js
+++ b/imports/plugins/core/core/server/publications/collections/orders.js
@@ -51,7 +51,7 @@ Meteor.publish("AccountOrders", function (accountId) {
 
   const account = this.userId ? Accounts.findOne({ userId: this.userId }) : null;
   const contextAccountId = account && account._id;
-  if (accountId !== contextAccountId && !Reaction.hasPermission("orders", Reaction.getUserId(), shopId)) {
+  if (accountId !== contextAccountId && !Reaction.hasPermission("reaction:legacy:orders/read", Reaction.getUserId(), shopId)) {
     return this.ready();
   }
 
@@ -99,7 +99,7 @@ Meteor.publish("OrderById", (orderId) => {
     return this.ready();
   }
 
-  if (Reaction.hasPermission("orders", Reaction.getUserId(), shopId)) {
+  if (Reaction.hasPermission("reaction:legacy:orders/read", Reaction.getUserId(), shopId)) {
     return Orders.find({
       $or: [
         { _id: orderId },

--- a/imports/plugins/core/core/server/publications/collections/product.js
+++ b/imports/plugins/core/core/server/publications/collections/product.js
@@ -102,7 +102,7 @@ Meteor.publish("Product", function (productIdOrHandle, shopIdOrSlug) {
 
   // Authorized content curators for the shop get special publication of the product
   // all all relevant revisions all is one package
-  if (Reaction.hasPermission(["owner", "createProduct", "product/admin", "product/update"], this.userId, product.shopId)) {
+  if (Reaction.hasPermission(["reaction:legacy:products/update"], this.userId, product.shopId)) {
     selector.isVisible = {
       $in: [true, false, undefined]
     };

--- a/imports/plugins/core/core/server/publications/collections/tags.js
+++ b/imports/plugins/core/core/server/publications/collections/tags.js
@@ -17,7 +17,7 @@ Meteor.publish("Tags", function (tagIds) {
   const shopId = Reaction.getShopId();
 
   // Only let users what have createProduct permissions see the tags
-  if (!Reaction.hasPermission(["createProduct", "product/admin", "product/update"], this.userId)) {
+  if (!Reaction.hasPermission(["reaction:legacy:tags/read"], this.userId)) {
     return this.ready();
   }
 

--- a/imports/plugins/core/core/server/publications/email.js
+++ b/imports/plugins/core/core/server/publications/email.js
@@ -14,7 +14,7 @@ Meteor.publish("Emails", function (query, options) {
   check(query, Match.Optional(Object));
   check(options, Match.Optional(Object));
 
-  if (Reaction.hasPermission(["owner", "admin", "reaction-email"], this.userId)) {
+  if (Reaction.hasPermission(["reaction:legacy:emails/read"], this.userId)) {
     Counts.publish(this, "emails-count", Jobs.find({ type: "sendEmail" }));
     return Jobs.find({ type: "sendEmail" });
   }

--- a/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
+++ b/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
@@ -37,7 +37,7 @@ function composer(props, onData) {
     dashboardHeaderTemplate: props.data.dashboardHeader,
     isActionViewAtRootView: Reaction.isActionViewAtRootView(),
     actionViewIsOpen: Reaction.isActionViewOpen(),
-    hasCreateProductAccess: Reaction.hasPermission(["createProduct", "product/admin", "product/create"], Reaction.getUserId(), Reaction.getShopId()),
+    hasCreateProductAccess: Reaction.hasPermission(["reaction:legacy:products/create"], Reaction.getUserId(), Reaction.getShopId()),
     shopId: Reaction.getShopId(),
     shops,
 

--- a/imports/plugins/core/orders/client/components/OrderAppBar.js
+++ b/imports/plugins/core/orders/client/components/OrderAppBar.js
@@ -13,7 +13,7 @@ import cancelOrderItemMutation from "../graphql/mutations/cancelOrderItem";
  * @returns {React.Component} returns a React component
  */
 function OrderAppBar(props) {
-  const hasPermission = Reaction.hasPermission(["reaction-orders", "order/fulfillment"], Reaction.getUserId(), Reaction.getShopId());
+  const hasPermission = Reaction.hasPermission(["reaction:legacy:orders/update"], Reaction.getUserId(), Reaction.getShopId());
   const { order } = props;
   const canCancelOrder = (order.status !== "coreOrderWorkflow/canceled");
 

--- a/imports/plugins/core/orders/client/components/OrderCardFulfillmentGroupStatusButton.js
+++ b/imports/plugins/core/orders/client/components/OrderCardFulfillmentGroupStatusButton.js
@@ -12,7 +12,7 @@ import updateOrderFulfillmentGroupMutation from "../graphql/mutations/updateOrde
  * @returns {React.Component} returns a React component
  */
 function OrderCardFulfillmentGroupStatusButton({ fulfillmentGroup, order }) {
-  const hasPermission = Reaction.hasPermission(["reaction-orders", "order/fulfillment"], Reaction.getUserId(), Reaction.getShopId());
+  const hasPermission = Reaction.hasPermission(["reaction:legacy:orders/update"], Reaction.getUserId(), Reaction.getShopId());
   const [updateOrderFulfillmentGroup, { loading: updateOrderFulfillmentGroupLoading }] = useMutation(updateOrderFulfillmentGroupMutation);
   const canUpdateFulfillmentStatus = (fulfillmentGroup.status !== "coreOrderWorkflow/canceled");
   const options = [

--- a/imports/plugins/core/orders/client/components/OrderCardFulfillmentGroupTrackingNumber.js
+++ b/imports/plugins/core/orders/client/components/OrderCardFulfillmentGroupTrackingNumber.js
@@ -28,7 +28,7 @@ class OrderCardFulfillmentGroupTrackingNumber extends Component {
   };
 
   handleSubmitForm = () => {
-    const hasPermission = Reaction.hasPermission(["reaction-orders", "order/fulfillment"], Reaction.getUserId(), Reaction.getShopId());
+    const hasPermission = Reaction.hasPermission(["reaction:legacy:orders/update"], Reaction.getUserId(), Reaction.getShopId());
 
     if (hasPermission) {
       this.form.submit();
@@ -36,7 +36,7 @@ class OrderCardFulfillmentGroupTrackingNumber extends Component {
   };
 
   handleToggleEdit = () => {
-    const hasPermission = Reaction.hasPermission(["reaction-orders", "order/fulfillment"], Reaction.getUserId(), Reaction.getShopId());
+    const hasPermission = Reaction.hasPermission(["reaction:legacy:orders/update"], Reaction.getUserId(), Reaction.getShopId());
 
     if (hasPermission) {
       this.setState({
@@ -46,7 +46,7 @@ class OrderCardFulfillmentGroupTrackingNumber extends Component {
   };
 
   handleUpdateFulfillmentGroupTrackingNumber = (data, mutation) => {
-    const hasPermission = Reaction.hasPermission(["reaction-orders", "order/fulfillment"], Reaction.getUserId(), Reaction.getShopId());
+    const hasPermission = Reaction.hasPermission(["reaction:legacy:orders/update"], Reaction.getUserId(), Reaction.getShopId());
 
     if (hasPermission) {
       const { fulfillmentGroup, orderId } = this.props;
@@ -68,7 +68,7 @@ class OrderCardFulfillmentGroupTrackingNumber extends Component {
   }
 
   render() {
-    const hasPermission = Reaction.hasPermission(["reaction-orders", "order/fulfillment"], Reaction.getUserId(), Reaction.getShopId());
+    const hasPermission = Reaction.hasPermission(["reaction:legacy:orders/update"], Reaction.getUserId(), Reaction.getShopId());
     const { fulfillmentGroup } = this.props;
     const { isEditing, trackingNumber } = this.state;
 

--- a/imports/plugins/core/orders/client/components/OrderCardFulfillmentGroups.js
+++ b/imports/plugins/core/orders/client/components/OrderCardFulfillmentGroups.js
@@ -64,7 +64,7 @@ class OrderCardFulfillmentGroups extends Component {
   };
 
   handleCancelFulfillmentGroup(mutation, fulfillmentGroup) {
-    const hasPermission = Reaction.hasPermission(["reaction-orders", "order/fulfillment"], Reaction.getUserId(), Reaction.getShopId());
+    const hasPermission = Reaction.hasPermission(["reaction:legacy:orders/update"], Reaction.getUserId(), Reaction.getShopId());
 
     if (hasPermission) {
       const { order } = this.props;
@@ -88,7 +88,7 @@ class OrderCardFulfillmentGroups extends Component {
   }
 
   renderCancelFulfillmentGroupButton = (fulfillmentGroup) => {
-    const hasPermission = Reaction.hasPermission(["reaction-orders", "order/fulfillment"], Reaction.getUserId(), Reaction.getShopId());
+    const hasPermission = Reaction.hasPermission(["reaction:legacy:orders/update"], Reaction.getUserId(), Reaction.getShopId());
 
     if (hasPermission) {
       const canCancelOrder = (fulfillmentGroup.status !== "coreOrderWorkflow/canceled");
@@ -144,7 +144,7 @@ class OrderCardFulfillmentGroups extends Component {
   }
 
   renderUpdateFulfillmentGroupStatusButton = (fulfillmentGroup) => {
-    const hasPermission = Reaction.hasPermission(["reaction-orders", "order/fulfillment"], Reaction.getUserId(), Reaction.getShopId());
+    const hasPermission = Reaction.hasPermission(["reaction:legacy:orders/update"], Reaction.getUserId(), Reaction.getShopId());
     const { order } = this.props;
     const canUpdateFulfillmentStatus = (fulfillmentGroup.status !== "coreOrderWorkflow/canceled");
 

--- a/imports/plugins/core/orders/client/components/OrderPayment.js
+++ b/imports/plugins/core/orders/client/components/OrderPayment.js
@@ -36,7 +36,7 @@ const displayStatuses = {
  * @returns {React.Component} returns a React component
  */
 function OrderPayment(props) {
-  const hasPermission = Reaction.hasPermission(["reaction-orders", "order/fulfillment"], Reaction.getUserId(), Reaction.getShopId());
+  const hasPermission = Reaction.hasPermission(["reaction:legacy:orders/capture:payment"], Reaction.getUserId(), Reaction.getShopId());
   const { classes, order, payment } = props;
   const { amount, captureErrorMessage, displayName, processor, riskLevel, status, transactionId } = payment;
   const canCapturePayment = payment.mode !== "captured";

--- a/imports/plugins/core/orders/client/components/OrderPayments.js
+++ b/imports/plugins/core/orders/client/components/OrderPayments.js
@@ -31,7 +31,7 @@ const styles = (theme) => ({
  * @returns {React.Component} returns a React component
  */
 function OrderPayments(props) {
-  const hasPermission = Reaction.hasPermission(["reaction-orders", "order/fulfillment"], Reaction.getUserId(), Reaction.getShopId());
+  const hasPermission = Reaction.hasPermission(["reaction:legacy:orders/capture:payment"], Reaction.getUserId(), Reaction.getShopId());
   const { classes, order } = props;
   const canCapturePayment = order.payments.some((payment) => payment.mode !== "captured");
   const [approveOrderPayments] = useMutation(approveOrderPaymentsMutation);

--- a/imports/plugins/core/tags/server/methods.js
+++ b/imports/plugins/core/tags/server/methods.js
@@ -9,7 +9,7 @@ Meteor.methods({
     check(excludedTagIds, Match.OneOf(undefined, Array));
 
     // Return a blank result set for non admins
-    if (!Reaction.hasPermission(["admin", "owner", "createProduct", "product/admin", "product/update"], this.userId)) {
+    if (!Reaction.hasPermission(["reaction:legacy:products/update"], this.userId)) {
       return [];
     }
 

--- a/imports/plugins/core/templates/server/methods.js
+++ b/imports/plugins/core/templates/server/methods.js
@@ -30,7 +30,7 @@ export const methods = {
     const userId = Reaction.getUserId();
 
     // Check that this user has permission to update templates for the active shop
-    if (!Reaction.hasPermission("reaction-templates", userId, shopId)) {
+    if (!Reaction.hasPermission("reaction:legacy:email-templates/update", userId, shopId)) {
       throw new ReactionError("access-denied", "Access Denied");
     }
 

--- a/imports/plugins/included/discount-codes/server/methods/methods.js
+++ b/imports/plugins/included/discount-codes/server/methods/methods.js
@@ -25,7 +25,7 @@ export const methods = {
 
     const shopId = Reaction.getShopId();
 
-    if (!Reaction.hasPermission("discounts", Reaction.getUserId(), shopId)) {
+    if (!Reaction.hasPermission("reaction:legacy:discounts/create", Reaction.getUserId(), shopId)) {
       throw new ReactionError("access-denied", "Access Denied");
     }
 
@@ -48,7 +48,7 @@ export const methods = {
 
     const shopId = Reaction.getShopId();
 
-    if (!Reaction.hasPermission("discounts", Reaction.getUserId(), shopId)) {
+    if (!Reaction.hasPermission("reaction:legacy:discounts/update", Reaction.getUserId(), shopId)) {
       throw new ReactionError("access-denied", "Access Denied");
     }
 
@@ -68,7 +68,7 @@ export const methods = {
 
     const shopId = Reaction.getShopId();
 
-    if (!Reaction.hasPermission("discounts", Reaction.getUserId(), shopId)) {
+    if (!Reaction.hasPermission("reaction:legacy:discounts/delete", Reaction.getUserId(), shopId)) {
       throw new ReactionError("access-denied", "Access Denied");
     }
 

--- a/imports/plugins/included/product-admin/client/components/ProductHeader.js
+++ b/imports/plugins/included/product-admin/client/components/ProductHeader.js
@@ -66,8 +66,8 @@ function ProductHeader(props) {
 
   const currentProduct = variant || product;
 
-  const hasCloneProductPermission = Reaction.hasPermission(["createProduct", "product/admin", "product/clone"], Reaction.getUserId(), Reaction.getShopId());
-  const hasArchiveProductPermission = Reaction.hasPermission(["createProduct", "product/admin", "product/archive"], Reaction.getUserId(), Reaction.getShopId());
+  const hasCloneProductPermission = Reaction.hasPermission(["reaction:legacy:products/clone"], Reaction.getUserId(), Reaction.getShopId());
+  const hasArchiveProductPermission = Reaction.hasPermission(["reaction:legacy:products/archive"], Reaction.getUserId(), Reaction.getShopId());
 
   // Archive menu item
   let archiveMenuItem = (

--- a/imports/plugins/included/product-admin/client/components/ProductList.js
+++ b/imports/plugins/included/product-admin/client/components/ProductList.js
@@ -51,7 +51,7 @@ function ProductList({ items, title, onCreate, selectedVariantId }) {
     return null;
   }
 
-  const hasCreateProductPermission = Reaction.hasPermission(["createProduct", "product/admin", "product/create"], Reaction.getUserId(), Reaction.getShopId());
+  const hasCreateProductPermission = Reaction.hasPermission(["reaction:legacy:products/create"], Reaction.getUserId(), Reaction.getShopId());
 
   return (
     <Card>

--- a/imports/plugins/included/product-admin/client/hocs/withProductMedia.js
+++ b/imports/plugins/included/product-admin/client/hocs/withProductMedia.js
@@ -135,7 +135,7 @@ function composer(props, onData) {
   });
 
   onData(null, {
-    editable: Reaction.hasPermission(props.permission || ["createProduct", "product/admin", "product/update"]),
+    editable: Reaction.hasPermission(props.permission || ["reaction:legacy:media/update", "reaction:legacy:mediaRecords/update:media"]),
     media: sortMedia(media),
     shopId: Reaction.getShopId(),
     productId,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reaction",
-  "version": "3.0.0-alpha",
+  "version": "3.0.0-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3811,7 +3811,7 @@
       "dependencies": {
         "buffer": {
           "version": "4.9.1",
-          "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
           "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
           "requires": {
             "base64-js": "^1.0.2",


### PR DESCRIPTION
Resolves #issueNumber  
Impact: **major**  
Type: **featurer|refactor**

## Issue
User permissions are currently checked against the `user.roles` object that is on a `user`. In the API, we've updated how permission work and now get `permissions` (formerly `roles`) by querying the groups a user belongs too, and attaching the permissions to a user based on the groups permissions.

## Solution
Update `reaction-admin` to get `permissions` based off of `account.groups` rather than `user.roles`. In addition, update all `Reaction.hasPermission()` checks to use the new permissions we use in the api. 

## Breaking changes
None

## Testing
1. See that `Reaction.hasPermission` works as expected