### PR TITLE
feat: point to /graphql instead of /graphql-beta

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,8 @@ PORT=4080
 OAUTH2_ADMIN_URL=http://hydra.auth.reaction.localhost:4445
 OAUTH2_IDP_PUBLIC_CHANGE_PASSWORD_URL=http://localhost:4100/account/change-password?email=EMAIL&from=FROM
 OAUTH2_PUBLIC_URL=http://localhost:4444
-PUBLIC_GRAPHQL_API_URL_HTTP=http://localhost:3000/graphql-beta
-PUBLIC_GRAPHQL_API_URL_WS=ws://localhost:3000/graphql-beta
+PUBLIC_GRAPHQL_API_URL_HTTP=http://localhost:3000/graphql
+PUBLIC_GRAPHQL_API_URL_WS=ws://localhost:3000/graphql
 PUBLIC_FILES_BASE_URL=http://localhost:3000
 PUBLIC_I18N_BASE_URL=http://localhost:3000
 PUBLIC_STOREFRONT_HOME_URL=http://localhost:4000

--- a/imports/plugins/core/core/server/config.js
+++ b/imports/plugins/core/core/server/config.js
@@ -18,12 +18,12 @@ export default envalid.cleanEnv(process.env, {
   }),
   PUBLIC_GRAPHQL_API_URL_HTTP: str({
     desc: "A URL that is accessible from browsers and accepts GraphQL POST requests over HTTP",
-    example: "http://localhost:3000/graphql-beta"
+    example: "http://localhost:3000/graphql"
   }),
   PUBLIC_GRAPHQL_API_URL_WS: str({
     default: "",
     desc: "A URL that is accessible from browsers and accepts GraphQL WebSocket connections",
-    example: "ws://localhost:3000/graphql-beta"
+    example: "ws://localhost:3000/graphql"
   }),
   PUBLIC_FILES_BASE_URL: str({
     desc: "A URL that has /assets/files and /assets/uploads endpoints for uploading and downloading files",


### PR DESCRIPTION
Impact: **minor**  
Type: **feature**

## Changes
Use `/graphql` rather than `/graphql-beta` for API requests.

## Breaking changes
None

## Testing
Verify app starts and loads in browser.