### PR TITLE
chore: reconfigure docker-compose networks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
 METEOR_DISABLE_OPTIMISTIC_CACHING=1
 METEOR_WATCH_POLLING_INTERVAL_MS=10000
-MONGO_OPLOG_URL=mongodb://mongo:27017/local
-MONGO_URL=mongodb://mongo:27017/reaction
+MONGO_OPLOG_URL=mongodb://mongo.reaction.localhost:27017/local
+MONGO_URL=mongodb://mongo.reaction.localhost:27017/reaction
 PORT=4080
-OAUTH2_ADMIN_URL=http://hydra.auth.reaction.localhost:4445
+OAUTH2_ADMIN_URL=http://hydra.reaction.localhost:4445
 OAUTH2_IDP_PUBLIC_CHANGE_PASSWORD_URL=http://localhost:4100/account/change-password?email=EMAIL&from=FROM
 OAUTH2_PUBLIC_URL=http://localhost:4444
 PUBLIC_GRAPHQL_API_URL_HTTP=http://localhost:3000/graphql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,18 +7,9 @@
 version: '3.4'
 
 networks:
-  api:
-    external:
-      name: api.reaction.localhost
-  auth:
-    external:
-      name: auth.reaction.localhost
   reaction:
     external:
       name: reaction.localhost
-  streams:
-    external:
-      name: streams.reaction.localhost
 
 services:
   reaction-admin:
@@ -26,10 +17,8 @@ services:
     env_file:
       - ./.env
     networks:
-      api:
-      auth:
+      default:
       reaction:
-      streams:
     ports:
       - "4080:4080"
       - "9231:9229"

--- a/imports/plugins/core/core/server/config.js
+++ b/imports/plugins/core/core/server/config.js
@@ -5,7 +5,7 @@ const { num, str } = envalid;
 export default envalid.cleanEnv(process.env, {
   OAUTH2_ADMIN_URL: str({
     desc: "An OAuth2 OpenID Connect compliant URL",
-    example: "http://hydra.auth.reaction.localhost:4445"
+    example: "http://hydra.reaction.localhost:4445"
   }),
   OAUTH2_CLIENT_ID: str({
     default: "reaction-admin",


### PR DESCRIPTION
There are 5 related PRs that should be tested together:
https://github.com/reactioncommerce/example-storefront/pull/653
https://github.com/reactioncommerce/reaction-hydra/pull/46
https://github.com/reactioncommerce/reaction-admin/pull/194
https://github.com/reactioncommerce/reaction-identity/pull/23
https://github.com/reactioncommerce/reaction/pull/6068

All of these ensure that docker-compose defines exactly one external network named `reaction.localhost` and update all services and ENV to use that one. This is being done to cut down on confusion caused by having various arbitrary networks. This affects only local development using docker-compose.

The only downside we're aware of is that project authors need to be more careful about giving Reaction services unique names (e.g., can't call them all `web`).

One upside in addition to being generally less confusing is that the primary internal hostname for the API is now just `api.reaction.localhost` rather than the more confusing `api.api.reaction.localhost`.

## Testing
1. Switch to the PR branches of all 5 projects linked above.
2. Copy `.env.example` to `.env` in each project, completely replacing `.env`.
3. Stop all Docker containers.
4. `docker system prune`
5. Delete the `docker-compose.override.yml` file from each of the project directories. It doesn't technically matter whether you leave the override in place, but everything will start faster if you don't.
6. In the platform directory, `make start`.
7. Once all services are running, check all service logs for errors, and do some basic smoke tests such as logging in to both admin and storefront.