### PR TITLE
fix: list accepted CSV mime types

### DIFF
--- a/imports/plugins/included/product-admin/client/components/ProductTable.js
+++ b/imports/plugins/included/product-admin/client/components/ProductTable.js
@@ -24,6 +24,18 @@ mutation createProduct($input: CreateProductInput!) {
 }
 `;
 
+const CSV_FILE_TYPES = [
+  "text/csv",
+  "text/plain",
+  "text/x-csv",
+  "application/vnd.ms-excel",
+  "application/csv",
+  "application/x-csv",
+  "text/comma-separated-values",
+  "text/x-comma-separated-values",
+  "text/tab-separated-values"
+];
+
 /**
  * ProductTable component
  * @returns {Node} React node
@@ -94,10 +106,11 @@ function ProductTable() {
   };
 
   const { getRootProps, getInputProps } = useDropzone({
-    onDrop,
-    multiple: true,
+    accept: CSV_FILE_TYPES,
+    disableClick: true,
     disablePreview: true,
-    disableClick: true
+    multiple: true,
+    onDrop
   });
 
   const handleShowFilterByFile = (isVisible) => {

--- a/imports/plugins/included/product-admin/client/components/ProductsTable.js
+++ b/imports/plugins/included/product-admin/client/components/ProductsTable.js
@@ -30,6 +30,18 @@ const useStyles = makeStyles({
   }
 });
 
+const CSV_FILE_TYPES = [
+  "text/csv",
+  "text/plain",
+  "text/x-csv",
+  "application/vnd.ms-excel",
+  "application/csv",
+  "application/x-csv",
+  "text/comma-separated-values",
+  "text/x-comma-separated-values",
+  "text/tab-separated-values"
+];
+
 /**
  * @summary Main products view
  * @name ProductsTable
@@ -182,11 +194,13 @@ function ProductsTable() {
 
   // Filter by file event handlers
   const { getRootProps, getInputProps } = useDropzone({
-    onDrop,
-    multiple: false,
+    accept: CSV_FILE_TYPES,
+    disableClick: true,
     disablePreview: true,
-    disableClick: true
+    multiple: false,
+    onDrop
   });
+
   const importFiles = (newFiles) => {
     let productIds = [];
 


### PR DESCRIPTION
Implementing the changes from https://github.com/reactioncommerce/reaction/pull/5785 in 3.0 stream.

## Testing
On Products page, verify that you can only drop/select CSV and text files when filtering by CSV. Verify that CSV files generated by Microsoft Excel work when viewing the page on Windows OS.