### PR TITLE
release v3.0.0 (beta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,100 +1,69 @@
-# v3.0.0-beta.3
+# v3.0.0
 
-This is the third beta release of the Reaction Admin project that is designed to work with our new Reaction API.
+This is the v3.0.0 (beta) release of `reaction-admin`, designed to work with v3.0.0 of the Reaction API. This project is a fork of the 2.x version of Reaction, updated to remove any `api` related features from this project and make this strictly an Admin UI that connects to the [Reaction API](https://github.com/reactioncommerce/reaction).
 
-*Reaction releases will no longer be coordinated across all projects - we'll release each project, independently, as needed. This means version numbers will no longer be in sync. The newest versions of each project will work together. This change has two exceptions: we will release all projects in coordination for a `beta` release, and all projects in coordination for the official `v3.0.0` release.*
-
-### Features
+## Features
 
 - feat: product table improvements [#195](https://github.com/reactioncommerce/reaction-admin/pull/195)
-
-### Refactors
-
-- refactor: remove alanning:roles and related user roles code [#193](https://github.com/reactioncommerce/reaction-admin/pull/193)
-
-# v3.0.0-beta.2
-
-This is the second beta release of the Reaction Admin project that is designed to work with our new Reaction API.
-
-*Reaction releases will no longer be coordinated across all projects - we'll release each project, independently, as needed. This means version numbers will no longer be in sync. The newest versions of each project will work together. This change has two exceptions: we will release all projects in coordination for a `beta` release, and all projects in coordination for the official `v3.0.0` release.*
-
-### Features
-
 - feat: use new Catalyst data table in products view an#182d update orders view [#182](https://github.com/reactioncommerce/reaction-admin/pull/182)
 - feat: point to /graphql instead of /graphql-beta [#190](https://github.com/reactioncommerce/reaction-admin/pull/190)
+- feat: add product page title [#175](https://github.com/reactioncommerce/reaction-admin/pull/175)
+- feat: Add account shop creation [#5](https://github.com/reactioncommerce/reaction-admin/pull/5)
+- feat: Remove `/operator` prefix from all routes [#6](https://github.com/reactioncommerce/reaction-admin/pull/6)
+- feat: Change server to port `4080` (from port `4040`) [#31](https://github.com/reactioncommerce/reaction-admin/pull/31)
+- feat: Use `Notistack` to display user notifications [#76](https://github.com/reactioncommerce/reaction-admin/pull/76)
+- feat: Remove OAuth/identity plugin [#82](https://github.com/reactioncommerce/reaction-admin/pull/82)
+- feat: Update to Meteor 1.8.1 [#87](https://github.com/reactioncommerce/reaction-admin/pull/87)
+- feat: Move client config to `.env` [#92](https://github.com/reactioncommerce/reaction-admin/pull/92)
+- feat: Updated UI for all tax settings [#127](https://github.com/reactioncommerce/reaction-admin/pull/127)
 
-### Chores
-
-- chore: reconfigure docker-compose networks [#194](https://github.com/reactioncommerce/reaction-admin/pull/194)
-
-### Fixes
+## Fixes
 
 - fix: show product not found in products table [#167](https://github.com/reactioncommerce/reaction-admin/pull/167)
+- fix: use updateProductVariantPrices mutation to save variant price [#172](https://github.com/reactioncommerce/reaction-admin/pull/172)
+- fix: Allow variant fields to be updated on page refresh [#174](https://github.com/reactioncommerce/reaction-admin/pull/174)
+- fix: prop types errors [#180](https://github.com/reactioncommerce/reaction-admin/pull/180)
+- fix: query missing `$` in front of `shopId` [#83](https://github.com/reactioncommerce/reaction-admin/pull/83)
+- fix: `reactioncommerce/admin` Docker image that is built and pushed to DockerHub when this is merged to trunk [#86](https://github.com/reactioncommerce/reaction-admin/pull/86)
+- fix: Resolves some reaction-admin bugs such as: creating products and updating them works well now, publishing products, tag page, and navigation [#89](https://github.com/reactioncommerce/reaction-admin/pull/89)
+- fix: Resolve port conflict `9229` with core reaction [#90](https://github.com/reactioncommerce/reaction-admin/pull/90)
+- fix: Make bin/setup always run from the desired path [#129](https://github.com/reactioncommerce/reaction-admin/pull/129)
 
-### Refactors
+## Refactors
 
+- refactor: remove alanning:roles and related user roles code [#193](https://github.com/reactioncommerce/reaction-admin/pull/193)
 - refactor: get `permissions` from groups, not user object [#187](https://github.com/reactioncommerce/reaction-admin/pull/187)
+- refactor: use OAuth flows for login, reg, logout, change password [#171](https://github.com/reactioncommerce/reaction-admin/pull/171)
+- refactor: Merge the two routers into one simpler router [#3](https://github.com/reactioncommerce/reaction-admin/pull/3)
+- refactor: Add `shopId` to `defaultNavitgationTree` code to match updates to API [#45](https://github.com/reactioncommerce/reaction-admin/pull/45)
+- refactor: Remove old navigation and `tagnav` plugins [#75](https://github.com/reactioncommerce/reaction-admin/pull/75)
+- refactor: Remove UI to set Stripe API settings [#88](https://github.com/reactioncommerce/reaction-admin/pull/88)
 
-### Docs
+## Chores
+
+- chore: reconfigure docker-compose networks [#194](https://github.com/reactioncommerce/reaction-admin/pull/194)
+- chore: move packages collection and fix most pages [#166](https://github.com/reactioncommerce/reaction-admin/pull/166)
+- chore: Add missing dependency for `subscriptions-transport-ws` [#32](https://github.com/reactioncommerce/reaction-admin/pull/32)
+- chore: Use published image for docker-compose [#131](https://github.com/reactioncommerce/reaction-admin/pull/131)
+
+## Docs
 
 - docs: update links to use trunk branch of docs [#189](https://github.com/reactioncommerce/reaction-admin/pull/189)
 
-# v3.0.0-beta
+*These changes were originally tested and released in our alpha and beta releases*
 
-This is the beta release of the Reaction Admin project that is designed to work with our new Reaction API.
+- [v3.0.0-beta.3](https://github.com/reactioncommerce/reaction-admin/releases/tag/v3.0.0-beta.3)
+- [v3.0.0-beta.2](https://github.com/reactioncommerce/reaction-admin/releases/tag/v3.0.0-beta.2)
+- [v3.0.0-beta](https://github.com/reactioncommerce/reaction-admin/releases/tag/v3.0.0-beta)
+- [v3.0.0-alpha](https://github.com/reactioncommerce/reaction-admin/releases/tag/v3.0.0-alpha)
 
-*Reaction releases will no longer be coordinated across all projects - we'll release each project, independently, as needed. This means version numbers will no longer be in sync. The newest versions of each project will work together. This change has two exceptions: we will release all projects in coordination for a `beta` release, and all projects in coordination for the official `v3.0.0` release.*
+*The following Reaction projects are being released one time in coordination as v3.0.0*
 
-### Features
+- [Reaction API](https://github.com/reactioncommerce/reaction)
+- [Reaction Hydra](https://github.com/reactioncommerce/reaction-hydra)
+- [Reaction Identity](https://github.com/reactioncommerce/reaction-identity)
+- [Reaction Admin (beta)](https://github.com/reactioncommerce/reaction-admin)
+- [Example Storefront](https://github.com/reactioncommerce/example-storefront)
+- [Reaction Development Platform](https://github.com/reactioncommerce/reaction-development-platform)
 
-- feat: add product page title [#175](https://github.com/reactioncommerce/reaction-admin/pull/175)
-
-### Chores
-
-- chore: move packages collection and fix most pages [#166](https://github.com/reactioncommerce/reaction-admin/pull/166)
-
-### Fixes
-
-- ix: use updateProductVariantPrices mutation to save variant price [#172](https://github.com/reactioncommerce/reaction-admin/pull/172)
-- fix: Allow variant fields to be updated on page refresh [#174](https://github.com/reactioncommerce/reaction-admin/pull/174)
-- fix: prop types errors [#180](https://github.com/reactioncommerce/reaction-admin/pull/180)
-
-### Refactors
-
-- refactor: use OAuth flows for login, reg, logout, change password [#171](https://github.com/reactioncommerce/reaction-admin/pull/171)
-
-# v3.0.0-alpha
-
-### Features
-
-- Add account shop creation [#5](https://github.com/reactioncommerce/reaction-admin/pull/5)
-- Remove `/operator` prefix from all routes [#6](https://github.com/reactioncommerce/reaction-admin/pull/6)
-- Change server to port `4080` (from port `4040`) [#31](https://github.com/reactioncommerce/reaction-admin/pull/31)
-- Use `Notistack` to display user notifications [#76](https://github.com/reactioncommerce/reaction-admin/pull/76)
-- Remove OAuth/identity plugin [#82](https://github.com/reactioncommerce/reaction-admin/pull/82)
-- Update to Meteor 1.8.1 [#87](https://github.com/reactioncommerce/reaction-admin/pull/87)
-- Move client config to `.env` [#92](https://github.com/reactioncommerce/reaction-admin/pull/92)
-- Updated UI for all tax settings [#127](https://github.com/reactioncommerce/reaction-admin/pull/127)
-
-
-### Chores
-
-- Add missing dependency for `subscriptions-transport-ws` [#32](https://github.com/reactioncommerce/reaction-admin/pull/32)
-- Use published image for docker-compose [#131](https://github.com/reactioncommerce/reaction-admin/pull/131)
-
-
-### Fixes
-
-- Fix query missing `$` in front of `shopId` [#83](https://github.com/reactioncommerce/reaction-admin/pull/83)
-- Fix `reactioncommerce/admin` Docker image that is built and pushed to DockerHub when this is merged to trunk [#86](https://github.com/reactioncommerce/reaction-admin/pull/86)
-- Resolves some reaction-admin bugs such as: creating products and updating them works well now, publishing products, tag page, and navigation [#89](https://github.com/reactioncommerce/reaction-admin/pull/89)
-- Resolve port conflict `9229` with core reaction [#90](https://github.com/reactioncommerce/reaction-admin/pull/90)
-- Make bin/setup always run from the desired path [#129](https://github.com/reactioncommerce/reaction-admin/pull/129)
-
-
-### Refactors
-
-- Merge the two routers into one simpler router [#3](https://github.com/reactioncommerce/reaction-admin/pull/3)
-- Add `shopId` to `defaultNavitgationTree` code to match updates to API [#45](https://github.com/reactioncommerce/reaction-admin/pull/45)
-- Remove old navigation and `tagnav` plugins [#75](https://github.com/reactioncommerce/reaction-admin/pull/75)
-- Remove UI to set Stripe API settings [#88](https://github.com/reactioncommerce/reaction-admin/pull/88)
+*After this release, Reaction releases will no longer be coordinated across all projects - we'll release each project independently, as needed. This means version numbers will no longer be in sync. The newest versions of each project will work together.*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "reaction",
-  "version": "3.0.0-beta.3",
+  "name": "reaction-admin",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3896,7 +3896,7 @@
       "dependencies": {
         "buffer": {
           "version": "4.9.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
           "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
           "requires": {
             "base64-js": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reaction-admin",
   "description": "Reaction is a modern reactive, real-time event driven ecommerce platform.",
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0",
   "main": "main.js",
   "directories": {
     "test": "tests"


### PR DESCRIPTION
# v3.0.0

This is the v3.0.0 (beta) release of `reaction-admin`, designed to work with v3.0.0 of the Reaction API. This project is a fork of the 2.x version of Reaction, updated to remove any `api` related features from this project and make this strictly an Admin UI that connects to the [Reaction API](https://github.com/reactioncommerce/reaction).

## Features

- feat: product table improvements [#195](https://github.com/reactioncommerce/reaction-admin/pull/195)
- feat: use new Catalyst data table in products view an#182d update orders view [#182](https://github.com/reactioncommerce/reaction-admin/pull/182)
- feat: point to /graphql instead of /graphql-beta [#190](https://github.com/reactioncommerce/reaction-admin/pull/190)
- feat: add product page title [#175](https://github.com/reactioncommerce/reaction-admin/pull/175)
- feat: Add account shop creation [#5](https://github.com/reactioncommerce/reaction-admin/pull/5)
- feat: Remove `/operator` prefix from all routes [#6](https://github.com/reactioncommerce/reaction-admin/pull/6)
- feat: Change server to port `4080` (from port `4040`) [#31](https://github.com/reactioncommerce/reaction-admin/pull/31)
- feat: Use `Notistack` to display user notifications [#76](https://github.com/reactioncommerce/reaction-admin/pull/76)
- feat: Remove OAuth/identity plugin [#82](https://github.com/reactioncommerce/reaction-admin/pull/82)
- feat: Update to Meteor 1.8.1 [#87](https://github.com/reactioncommerce/reaction-admin/pull/87)
- feat: Move client config to `.env` [#92](https://github.com/reactioncommerce/reaction-admin/pull/92)
- feat: Updated UI for all tax settings [#127](https://github.com/reactioncommerce/reaction-admin/pull/127)

## Fixes

- fix: show product not found in products table [#167](https://github.com/reactioncommerce/reaction-admin/pull/167)
- fix: use updateProductVariantPrices mutation to save variant price [#172](https://github.com/reactioncommerce/reaction-admin/pull/172)
- fix: Allow variant fields to be updated on page refresh [#174](https://github.com/reactioncommerce/reaction-admin/pull/174)
- fix: prop types errors [#180](https://github.com/reactioncommerce/reaction-admin/pull/180)
- fix: query missing `$` in front of `shopId` [#83](https://github.com/reactioncommerce/reaction-admin/pull/83)
- fix: `reactioncommerce/admin` Docker image that is built and pushed to DockerHub when this is merged to trunk [#86](https://github.com/reactioncommerce/reaction-admin/pull/86)
- fix: Resolves some reaction-admin bugs such as: creating products and updating them works well now, publishing products, tag page, and navigation [#89](https://github.com/reactioncommerce/reaction-admin/pull/89)
- fix: Resolve port conflict `9229` with core reaction [#90](https://github.com/reactioncommerce/reaction-admin/pull/90)
- fix: Make bin/setup always run from the desired path [#129](https://github.com/reactioncommerce/reaction-admin/pull/129)

## Refactors

- refactor: remove alanning:roles and related user roles code [#193](https://github.com/reactioncommerce/reaction-admin/pull/193)
- refactor: get `permissions` from groups, not user object [#187](https://github.com/reactioncommerce/reaction-admin/pull/187)
- refactor: use OAuth flows for login, reg, logout, change password [#171](https://github.com/reactioncommerce/reaction-admin/pull/171)
- refactor: Merge the two routers into one simpler router [#3](https://github.com/reactioncommerce/reaction-admin/pull/3)
- refactor: Add `shopId` to `defaultNavitgationTree` code to match updates to API [#45](https://github.com/reactioncommerce/reaction-admin/pull/45)
- refactor: Remove old navigation and `tagnav` plugins [#75](https://github.com/reactioncommerce/reaction-admin/pull/75)
- refactor: Remove UI to set Stripe API settings [#88](https://github.com/reactioncommerce/reaction-admin/pull/88)

## Chores

- chore: reconfigure docker-compose networks [#194](https://github.com/reactioncommerce/reaction-admin/pull/194)
- chore: move packages collection and fix most pages [#166](https://github.com/reactioncommerce/reaction-admin/pull/166)
- chore: Add missing dependency for `subscriptions-transport-ws` [#32](https://github.com/reactioncommerce/reaction-admin/pull/32)
- chore: Use published image for docker-compose [#131](https://github.com/reactioncommerce/reaction-admin/pull/131)

## Docs

- docs: update links to use trunk branch of docs [#189](https://github.com/reactioncommerce/reaction-admin/pull/189)

*These changes were originally tested and released in our alpha and beta releases*

- [v3.0.0-beta.3](https://github.com/reactioncommerce/reaction-admin/releases/tag/v3.0.0-beta.3)
- [v3.0.0-beta.2](https://github.com/reactioncommerce/reaction-admin/releases/tag/v3.0.0-beta.2)
- [v3.0.0-beta](https://github.com/reactioncommerce/reaction-admin/releases/tag/v3.0.0-beta)
- [v3.0.0-alpha](https://github.com/reactioncommerce/reaction-admin/releases/tag/v3.0.0-alpha)

*The following Reaction projects are being released one time in coordination as v3.0.0*

- [Reaction API](https://github.com/reactioncommerce/reaction)
- [Reaction Hydra](https://github.com/reactioncommerce/reaction-hydra)
- [Reaction Identity](https://github.com/reactioncommerce/reaction-identity)
- [Reaction Admin (beta)](https://github.com/reactioncommerce/reaction-admin)
- [Example Storefront](https://github.com/reactioncommerce/example-storefront)
- [Reaction Development Platform](https://github.com/reactioncommerce/reaction-development-platform)

*After this release, Reaction releases will no longer be coordinated across all projects - we'll release each project independently, as needed. This means version numbers will no longer be in sync. The newest versions of each project will work together.*
