### PR TITLE
fix: remove `canInviteToGroup` helper on the client

### DIFF
--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -446,36 +446,6 @@ export default {
   },
 
   /**
-   * (similar to server/api canInviteToGroup)
-   * @name canInviteToGroup
-   * @method
-   * @memberof Core/Client
-   * @summary checks if the user making the request is allowed to make invitation to that group
-   * @param {Object} options -
-   * @param {Object} options.group - group to invite to
-   * @param {Object} options.user - user object  making the invite (Meteor.user())
-   * @returns {Boolean} -
-   */
-  canInviteToGroup(options) {
-    const { group } = options;
-    let { user } = options;
-    if (!user) {
-      user = Meteor.user();
-    }
-    const userPermissions = user.roles[group.shopId];
-    const groupPermissions = group.permissions;
-
-    // granting invitation right for user with `owner` role in a shop
-    if (this.hasPermission(["owner"], getUserId(), group.shopId)) {
-      return true;
-    }
-
-    // checks that userPermissions includes all elements from groupPermissions
-    // we are not using Reaction.hasPermission here because it returns true if the user has at least one
-    return _.difference(groupPermissions, userPermissions).length === 0;
-  },
-
-  /**
    * @name showActionView
    * @method
    * @memberof Core/Client

--- a/imports/plugins/core/accounts/client/components/adminInviteForm.js
+++ b/imports/plugins/core/accounts/client/components/adminInviteForm.js
@@ -30,7 +30,6 @@ const inviteShopMember = gql`
 
 class AdminInviteForm extends Component {
   static propTypes = {
-    canInviteToGroup: PropTypes.func,
     groups: PropTypes.array
   };
 

--- a/imports/plugins/core/accounts/client/components/groupsTableCell.js
+++ b/imports/plugins/core/accounts/client/components/groupsTableCell.js
@@ -54,13 +54,10 @@ const GroupsTableCell = (props) => {
     const groupName = group.name && _.startCase(group.name);
     const groupNameSpan = <span className="group-dropdown">{groupName}</span>;
     const ownerGroup = groups.find((grp) => grp.slug === "owner") || {};
-    const hasOwnerAccess = Reaction.hasPermission("reaction:legacy:groups/read", Reaction.getUserId(), Reaction.getShopId());
 
     // Permission check. Remove owner option, if user is not current owner.
     // Also remove groups user does not have roles to manage. This is also checked on the server
-    const dropOptions = groups
-      .filter((grp) => !((grp.slug === "owner" && !hasOwnerAccess)))
-      .filter((grp) => Reaction.canInviteToGroup({ group: grp })) || [];
+    const dropOptions = groups || [];
 
     if (dropOptions.length < 2) {
       return groupNameSpan;

--- a/imports/plugins/core/accounts/client/components/groupsTableCell.js
+++ b/imports/plugins/core/accounts/client/components/groupsTableCell.js
@@ -2,7 +2,6 @@ import React from "react";
 import _ from "lodash";
 import PropTypes from "prop-types";
 import { Components, registerComponent, withMoment } from "@reactioncommerce/reaction-components";
-import { Reaction } from "/client/api";
 import { getUserAvatar } from "/imports/plugins/core/accounts/client/helpers/helpers";
 
 const GroupsTableCell = (props) => {

--- a/imports/plugins/core/accounts/client/helpers/accountsHelper.js
+++ b/imports/plugins/core/accounts/client/helpers/accountsHelper.js
@@ -52,9 +52,7 @@ export function sortGroups(groups) {
  * @returns {Array} - array of groups or empty object
  */
 export function getInvitableGroups(groups) {
-  return groups
-    .filter((grp) => grp.slug !== "owner")
-    .filter((grp) => Reaction.canInviteToGroup({ group: grp }));
+  return groups || [];
 }
 
 /**

--- a/imports/plugins/core/core/server/Reaction/core.js
+++ b/imports/plugins/core/core/server/Reaction/core.js
@@ -53,35 +53,6 @@ export default {
   defaultVisitorRoles: ["anonymous", "guest", "product", "tag", "index", "cart/completed"],
 
   /**
-   * @name canInviteToGroup
-   * @method
-   * @memberof Core
-   * @summary checks if the user making the request is allowed to make invitation to that group
-   * @param {Object} options -
-   * @param {Object} options.group - group to invite to
-   * @param {Object} options.user - user object  making the invite (Meteor.user())
-   * @returns {Boolean} -
-   */
-  canInviteToGroup(options) {
-    const { group } = options;
-    let { user } = options;
-    if (!user) {
-      user = Meteor.user();
-    }
-    const userPermissions = user.roles[group.shopId];
-    const groupPermissions = group.permissions;
-
-    // granting invitation right for user with `owner` role in a shop
-    if (this.hasPermission(["owner"], getUserId(), group.shopId)) {
-      return true;
-    }
-
-    // checks that userPermissions includes all elements from groupPermissions
-    // we are not using Reaction.hasPermission here because it returns true if the user has at least one
-    return _.difference(groupPermissions, userPermissions).length === 0;
-  },
-
-  /**
    * @name hasPermission
    * @method
    * @memberof Core

--- a/package-lock.json
+++ b/package-lock.json
@@ -8322,8 +8322,7 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
@@ -8347,7 +8346,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -10809,8 +10807,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -10853,8 +10850,7 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -10865,8 +10861,7 @@
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -10983,8 +10978,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -10996,7 +10990,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -11026,7 +11019,6 @@
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -11045,7 +11037,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -11126,8 +11117,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -11139,7 +11129,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -11225,8 +11214,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -11262,7 +11250,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -11282,7 +11269,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -11326,14 +11312,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },


### PR DESCRIPTION
Resolves #211 
Impact: **minor**
Type: **bugfix**

## Issue
## Issue Description

> After creating your first user, if you click on "Accounts" the screen is blank and it throws this error in the console:
> 
> ```
> TypeError: Cannot read property 'ixKfbghjg9tYLX9BZ' of undefined
>     at Object.canInviteToGroup (5650109b78b2a3b0e1a28555f19526d48d064113.js?meteor_js_resource=true:959)
>     at 5650109b78b2a3b0e1a28555f19526d48d064113.js?meteor_js_resource=true:959
>     at Array.filter (<anonymous>)
>     at Reaction(GroupsTableCell) (5650109b78b2a3b0e1a28555f19526d48d064113.js?meteor_js_resource=true:959)
> ```

## Solution
Remove the UI / client helper `canInviteToGroup`. This helper was checking permissions in a way we no longer support in `v3.0.0`.

This solution relies on the API's server side permissions checks to determine if a user has the correct permissions to perform an action. The client can be updated in the future to provide a pre-action warning / error / restriction, if desired.

## Breaking changes
Any custom code that uses `Reaction.canInviteToGroup` helper will need to be updated tor remove that helper.


## Testing
1. Create an account and a shop
1. See that you can view the `Accounts` page.
1. See that you can invite a user when you are an admin / have the correct permissions
1. See that you get a server error when you are not an admin / don't have the correct permissions