### PR TITLE
fix: correctly display total order amount

### DIFF
--- a/imports/plugins/core/orders/client/components/DataTable/OrderTotalCell.js
+++ b/imports/plugins/core/orders/client/components/DataTable/OrderTotalCell.js
@@ -1,0 +1,28 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Box } from "@material-ui/core";
+
+/**
+ * @name OrderTotalCell
+ * @param {Object} row A react-table row object
+ * @return {React.Component} A React component to render an order's total
+ */
+function OrderTotalCell({ row }) {
+  // Sum up all the payments on an orders. Since the API returns
+  // the payments already formatted, just use the currency symbol provided.
+  const currencySymbol = row.original.payments[0].amount.displayAmount.charAt(0);
+  const reducer = (accumulator, value) => accumulator + Number.parseFloat(value.amount.displayAmount.slice(1));
+  const total = row.original.payments.reduce(reducer, 0);
+
+  return (
+    <Box textAlign="right">
+      {currencySymbol}{total}
+    </Box>
+  );
+}
+
+OrderTotalCell.propTypes = {
+  row: PropTypes.object.isRequired
+};
+
+export default OrderTotalCell;

--- a/imports/plugins/core/orders/client/components/DataTable/OrderTotalCell.js
+++ b/imports/plugins/core/orders/client/components/DataTable/OrderTotalCell.js
@@ -8,15 +8,9 @@ import { Box } from "@material-ui/core";
  * @return {React.Component} A React component to render an order's total
  */
 function OrderTotalCell({ row }) {
-  // Sum up all the payments on an orders. Since the API returns
-  // the payments already formatted, just use the currency symbol provided.
-  const currencySymbol = row.original.payments[0].amount.displayAmount.charAt(0);
-  const reducer = (accumulator, value) => accumulator + Number.parseFloat(value.amount.displayAmount.slice(1));
-  const total = row.original.payments.reduce(reducer, 0);
-
   return (
     <Box textAlign="right">
-      {currencySymbol}{total}
+      {row.values["summary.total.displayAmount"]}
     </Box>
   );
 }

--- a/imports/plugins/core/orders/client/components/OrdersTable.js
+++ b/imports/plugins/core/orders/client/components/OrdersTable.js
@@ -96,7 +96,7 @@ function OrdersTable() {
       accessor: "payments[0].billingAddress.fullName"
     },
     {
-      accessor: "payments[0].amount.displayAmount",
+      accessor: "summary.total.displayAmount",
       // eslint-disable-next-line react/no-multi-comp,react/display-name,react/prop-types
       Header: () => <Box textAlign="right">{i18next.t("admin.table.headers.total")}</Box>,
       // eslint-disable-next-line react/no-multi-comp,react/display-name,react/prop-types

--- a/imports/plugins/core/orders/client/components/OrdersTable.js
+++ b/imports/plugins/core/orders/client/components/OrdersTable.js
@@ -11,6 +11,7 @@ import ordersQuery from "../graphql/queries/orders";
 import { formatDateRangeFilter } from "../../client/helpers";
 import OrderDateCell from "./DataTable/OrderDateCell";
 import OrderIdCell from "./DataTable/OrderIdCell";
+import OrderTotalCell from "./DataTable/OrderTotalCell";
 
 const useStyles = makeStyles({
   card: {
@@ -99,7 +100,7 @@ function OrdersTable() {
       // eslint-disable-next-line react/no-multi-comp,react/display-name,react/prop-types
       Header: () => <Box textAlign="right">{i18next.t("admin.table.headers.total")}</Box>,
       // eslint-disable-next-line react/no-multi-comp,react/display-name,react/prop-types
-      Cell: ({ cell }) => <Box textAlign="right">{cell.value}</Box>
+      Cell: ({ row }) => <OrderTotalCell row={row} />
     },
     {
       Header: i18next.t("admin.table.headers.date"),

--- a/imports/plugins/core/orders/client/graphql/queries/orders.js
+++ b/imports/plugins/core/orders/client/graphql/queries/orders.js
@@ -12,13 +12,15 @@ query ordersQuery($shopIds: [ID], $filters: OrderFilterInput, $first: Connection
         billingAddress {
           fullName
         }
-        amount { 
-          displayAmount
-        }
         status
       }
       fulfillmentGroups {
         status
+      }
+      summary {
+        total {
+          displayAmount
+        }
       }
       email
       status


### PR DESCRIPTION
Resolves #201 
Impact: **minor**
Type: **bugfix**

## Issue
In the orders table, the order total only took into account the amount of the first payment.

## Solution
Calculate an order's total by summing all payments


## Testing
1. Place an order and split the payment into multiple payments
2. Verify to order total is correctly rendered in the orders table.
