### PR TITLE
Add layout for primary/detail view

### DIFF
--- a/imports/client/ui/components/Sidebar/Sidebar.js
+++ b/imports/client/ui/components/Sidebar/Sidebar.js
@@ -241,7 +241,6 @@ Sidebar.propTypes = {
   isSettingsOpen: PropTypes.bool,
   isSidebarOpen: PropTypes.bool.isRequired,
   onDrawerClose: PropTypes.func.isRequired,
-  routes: PropTypes.array,
   setIsSettingsOpen: PropTypes.func.isRequired
 };
 

--- a/imports/client/ui/components/Sidebar/Sidebar.js
+++ b/imports/client/ui/components/Sidebar/Sidebar.js
@@ -107,7 +107,7 @@ function Sidebar(props) {
 
   const [isAppLoading] = useIsAppLoading();
   const [currentShopId] = useCurrentShopId();
-  const primaryRoutes = useOperatorRoutes({ groups: ["main"] });
+  const primaryRoutes = useOperatorRoutes({ groups: ["navigation"] });
   const settingRoutes = useOperatorRoutes({ groups: ["settings"] });
 
   let drawerProps = {

--- a/imports/client/ui/components/Sidebar/Sidebar.js
+++ b/imports/client/ui/components/Sidebar/Sidebar.js
@@ -20,6 +20,7 @@ import { Translation } from "/imports/plugins/core/ui/client/components";
 import useIsAppLoading from "/imports/client/ui/hooks/useIsAppLoading.js";
 import useCurrentShopId from "../../hooks/useCurrentShopId";
 import ShopLogoWithData from "../ShopLogoWithData";
+import useOperatorRoutes from "../../hooks/useOperatorRoutes";
 
 const activeClassName = "nav-item-active";
 
@@ -104,15 +105,13 @@ function Sidebar(props) {
     isSidebarOpen,
     onDrawerClose,
     isSettingsOpen,
-    setIsSettingsOpen,
-    routes
+    setIsSettingsOpen
   } = props;
 
   const [isAppLoading] = useIsAppLoading();
   const [currentShopId] = useCurrentShopId();
-
-  const primaryRoutes = routes.filter(({ isNavigationLink, isSetting }) => isNavigationLink && !isSetting).sort(routeSort);
-  const settingRoutes = routes.filter(({ isNavigationLink, isSetting }) => isNavigationLink && isSetting).sort(routeSort);
+  const primaryRoutes = useOperatorRoutes({ group: "main" });
+  const settingRoutes = useOperatorRoutes({ group: "settings" });
 
   let drawerProps = {
     classes: {

--- a/imports/client/ui/components/Sidebar/Sidebar.js
+++ b/imports/client/ui/components/Sidebar/Sidebar.js
@@ -24,9 +24,6 @@ import useOperatorRoutes from "../../hooks/useOperatorRoutes";
 
 const activeClassName = "nav-item-active";
 
-// Route sorting by priority. Items without a priority get pushed the bottom.
-const routeSort = (routeA, routeB) => (routeA.priority || Number.MAX_SAFE_INTEGER) - (routeB.priority || Number.MAX_SAFE_INTEGER);
-
 const styles = (theme) => ({
   closeButton: {
     "color": theme.palette.colors.white,
@@ -110,8 +107,8 @@ function Sidebar(props) {
 
   const [isAppLoading] = useIsAppLoading();
   const [currentShopId] = useCurrentShopId();
-  const primaryRoutes = useOperatorRoutes({ group: "main" });
-  const settingRoutes = useOperatorRoutes({ group: "settings" });
+  const primaryRoutes = useOperatorRoutes({ groups: ["main"] });
+  const settingRoutes = useOperatorRoutes({ groups: ["settings"] });
 
   let drawerProps = {
     classes: {

--- a/imports/client/ui/context/UIContext.js
+++ b/imports/client/ui/context/UIContext.js
@@ -7,5 +7,7 @@ export const UIContext = createContext({
   onCloseDetailDrawer: () => { },
   onClosePrimarySidebar: () => { },
   onToggleDetailDrawer: () => { },
-  onTogglePrimarySidebar: () => { }
+  onTogglePrimarySidebar: () => { },
+  setDetailDrawerOpen: () => { },
+  setPrimarySidebarOpen: () => { }
 });

--- a/imports/client/ui/hooks/useMediaQuery.js
+++ b/imports/client/ui/hooks/useMediaQuery.js
@@ -1,0 +1,20 @@
+import { useMediaQuery as useMediaQueryMui } from "@material-ui/core";
+
+/**
+ * Media query hook. Wraps the mui hook `useMediaQuery` with some additional options.
+ * @param {String} breakpoint Breakpoint name. `mobile|tablet|desktop|xs|sm|md|lg`
+ * @param {Options} options Options
+ * @returns {Boolean} Whether the breakpoint is active
+ */
+export default function useMediaQuery(breakpoint = "mobile", options) {
+  return useMediaQueryMui((theme) => {
+    if (breakpoint === "mobile") {
+      return theme.breakpoints.down("sm", options);
+    } else if (breakpoint === "tablet") {
+      return theme.breakpoints.down("md", options);
+    } else if (breakpoint === "desktop") {
+      return theme.breakpoints.up("md", options);
+    }
+    return theme.breakpoints.up(breakpoint, options);
+  });
+}

--- a/imports/client/ui/hooks/useOperatorRoutes.js
+++ b/imports/client/ui/hooks/useOperatorRoutes.js
@@ -1,0 +1,35 @@
+import { operatorRoutes } from "../index";
+
+export const defaultRouteSort = (routeA, routeB) => (routeA.priority || Number.MAX_SAFE_INTEGER) - (routeB.priority || Number.MAX_SAFE_INTEGER);
+
+/**
+ * Operator routes hook
+ * @param {Object} options Options
+ * @param {Object} [options.LayoutComponent] LayoutComponent override
+ * @param {Object} [options.group] Filter routes by group name
+ * @param {Object} [options.filter] Custom filter
+ * @param {Object} [options.sort] Route sort function
+ * @returns {Array} An array containing filtered routes
+ */
+export default function useOperatorRoutes(options) {
+  const {
+    group,
+    filter,
+    sort = defaultRouteSort
+  } = options;
+
+  let routes = operatorRoutes;
+
+  if (group) {
+    routes = operatorRoutes.filter(({ group: routeGroup }) => routeGroup === group);
+  } else if (filter) {
+    routes = operatorRoutes.filter(filter);
+  }
+
+  if (sort) {
+    routes = operatorRoutes.sort(sort);
+  }
+
+  return routes;
+}
+

--- a/imports/client/ui/hooks/useOperatorRoutes.js
+++ b/imports/client/ui/hooks/useOperatorRoutes.js
@@ -1,6 +1,9 @@
+import { useMemo } from "react";
 import { operatorRoutes } from "../index";
 
-export const defaultRouteSort = (routeA, routeB) => (routeA.priority || Number.MAX_SAFE_INTEGER) - (routeB.priority || Number.MAX_SAFE_INTEGER);
+export const defaultRouteSort = (routeA, routeB) => (
+  (routeA.priority || Number.MAX_SAFE_INTEGER) - (routeB.priority || Number.MAX_SAFE_INTEGER)
+);
 
 /**
  * Operator routes hook
@@ -11,25 +14,29 @@ export const defaultRouteSort = (routeA, routeB) => (routeA.priority || Number.M
  * @param {Object} [options.sort] Route sort function
  * @returns {Array} An array containing filtered routes
  */
-export default function useOperatorRoutes(options) {
+export default function useOperatorRoutes(options = {}) {
   const {
-    group,
+    groups,
     filter,
     sort = defaultRouteSort
   } = options;
 
-  let routes = operatorRoutes;
+  const routes = useMemo(() => {
+    let filteredRoutes;
+    if (Array.isArray(groups)) {
+      filteredRoutes = operatorRoutes.filter(({ group: routeGroup }) => groups.includes(routeGroup));
+    } else if (filter) {
+      filteredRoutes = operatorRoutes.filter(filter);
+    } else {
+      filteredRoutes = operatorRoutes;
+    }
 
-  if (group) {
-    routes = operatorRoutes.filter(({ group: routeGroup }) => routeGroup === group);
-  } else if (filter) {
-    routes = operatorRoutes.filter(filter);
-  }
+    if (sort) {
+      filteredRoutes = filteredRoutes.sort(sort);
+    }
 
-  if (sort) {
-    routes = operatorRoutes.sort(sort);
-  }
+    return filteredRoutes;
+  }, [filter, groups, sort]);
 
   return routes;
 }
-

--- a/imports/client/ui/index.js
+++ b/imports/client/ui/index.js
@@ -44,19 +44,21 @@ export function registerOperatorRoute(route) {
     additionalProps.LayoutComponent = layoutComponent;
   }
 
-  let component = MainComponent || mainComponent;
-
-  if (typeof component === "string") {
-    component = () => getReactComponentOrBlazeTemplate(component);
-  }
-
-  component = compose(...hocs, setDisplayName(`Reaction(${name})`))(component);
-
   if (mainComponent) {
     // eslint-disable-next-line no-console
     console.warn("Option `mainComponent` is deprecated. Use `MainComponent` instead");
-    additionalProps.MainComponent = component;
   }
+
+  const resolvedMainComponent = MainComponent || mainComponent;
+  let component;
+
+  if (typeof resolvedMainComponent === "string") {
+    component = () => getReactComponentOrBlazeTemplate(resolvedMainComponent);
+  } else {
+    component = resolvedMainComponent;
+  }
+
+  component = compose(...hocs, setDisplayName(`Reaction(${name})`))(component);
 
   operatorRoutes.push({
     ...route,

--- a/imports/client/ui/index.js
+++ b/imports/client/ui/index.js
@@ -5,6 +5,10 @@ import "./appComponents";
 
 export const operatorRoutes = [];
 export const routes = [];
+export const defaultRouteGroups = {
+  main: "main",
+  settings: "settings"
+};
 
 /**
  * @name registerOperatorRoute
@@ -19,8 +23,28 @@ export const routes = [];
  * @returns {undefined}
  */
 export function registerOperatorRoute(route) {
-  const { mainComponent, hocs = [] } = route;
-  let component = mainComponent;
+  const { isNavigationLink, isSetting, layoutComponent, mainComponent, MainComponent, hocs = [] } = route;
+  const additionalProps = {};
+
+  if (isNavigationLink) {
+    // eslint-disable-next-line no-console
+    console.warn("Option `isNavigationLink` is deprecated. Set `group: \"main\"` in your route configuration");
+    additionalProps.group = defaultRouteGroups.main;
+  }
+
+  if (isSetting) {
+    // eslint-disable-next-line no-console
+    console.warn("Option `isSetting` is deprecated. Set `group: \"settings\"` in your route configuration");
+    additionalProps.group = defaultRouteGroups.settings;
+  }
+
+  if (layoutComponent) {
+    // eslint-disable-next-line no-console
+    console.warn("Option `layoutComponent` is deprecated. Use `LayoutComponent` instead");
+    additionalProps.LayoutComponent = layoutComponent;
+  }
+
+  let component = MainComponent || mainComponent;
 
   if (typeof mainComponent === "string") {
     component = () => getReactComponentOrBlazeTemplate(mainComponent);
@@ -28,7 +52,17 @@ export function registerOperatorRoute(route) {
 
   component = compose(...hocs, setDisplayName(`Reaction(${name})`))(component);
 
-  operatorRoutes.push({ ...route, mainComponent: component });
+  if (mainComponent) {
+    // eslint-disable-next-line no-console
+    console.warn("Option `mainComponent` is deprecated. Use `MainComponent` instead");
+    additionalProps.MainComponent = component;
+  }
+
+  operatorRoutes.push({
+    ...route,
+    ...additionalProps,
+    mainComponent: component
+  });
 }
 
 /**

--- a/imports/client/ui/index.js
+++ b/imports/client/ui/index.js
@@ -46,8 +46,8 @@ export function registerOperatorRoute(route) {
 
   let component = MainComponent || mainComponent;
 
-  if (typeof mainComponent === "string") {
-    component = () => getReactComponentOrBlazeTemplate(mainComponent);
+  if (typeof component === "string") {
+    component = () => getReactComponentOrBlazeTemplate(component);
   }
 
   component = compose(...hocs, setDisplayName(`Reaction(${name})`))(component);

--- a/imports/client/ui/index.js
+++ b/imports/client/ui/index.js
@@ -61,7 +61,7 @@ export function registerOperatorRoute(route) {
   operatorRoutes.push({
     ...route,
     ...additionalProps,
-    mainComponent: component
+    MainComponent: component
   });
 }
 
@@ -90,6 +90,6 @@ export function registerRoute(route) {
   routes.push({
     exact: true,
     ...route,
-    mainComponent: component
+    MainComponent: component
   });
 }

--- a/imports/client/ui/index.js
+++ b/imports/client/ui/index.js
@@ -6,7 +6,7 @@ import "./appComponents";
 export const operatorRoutes = [];
 export const routes = [];
 export const defaultRouteGroups = {
-  main: "main",
+  navigation: "navigation",
   settings: "settings"
 };
 

--- a/imports/client/ui/layouts/ContentViewPrimaryDetailLayout.js
+++ b/imports/client/ui/layouts/ContentViewPrimaryDetailLayout.js
@@ -83,7 +83,7 @@ function ContentViewPrimaryDetailLayout(props) {
     PrimaryComponent,
     children,
     detailBlockRegionName,
-    drawerButtonTitle = "More",
+    drawerButtonTitle,
     primaryBlockRegionName,
     ...blockProps
   } = props;
@@ -168,9 +168,13 @@ ContentViewPrimaryDetailLayout.propTypes = {
   PrimaryComponent: PropTypes.node,
   children: PropTypes.node,
   detailBlockRegionName: PropTypes.string,
-  drawerButtonTitle: PropTypes.string.isRequired,
+  drawerButtonTitle: PropTypes.string,
   isMobile: PropTypes.bool,
   primaryBlockRegionName: PropTypes.string
+};
+
+ContentViewPrimaryDetailLayout.defaultProps = {
+  drawerButtonTitle: "More"
 };
 
 export default ContentViewPrimaryDetailLayout;

--- a/imports/client/ui/layouts/ContentViewPrimaryDetailLayout.js
+++ b/imports/client/ui/layouts/ContentViewPrimaryDetailLayout.js
@@ -1,10 +1,9 @@
 /**
  * Component provides a regions for a primary (sidebar) and detail view
  */
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
-import withStyles from "@material-ui/core/styles/withStyles";
 import Button from "@reactioncommerce/catalyst/Button";
 import { Blocks } from "@reactioncommerce/reaction-components";
 import {
@@ -13,21 +12,35 @@ import {
   Drawer,
   Toolbar,
   IconButton,
-  Typography
+  makeStyles
 } from "@material-ui/core";
-import CloseIcon from "mdi-material-ui/Close";
+import ChevronDownIcon from "mdi-material-ui/ChevronDown";
 import useMediaQuery from "../hooks/useMediaQuery";
+import { UIContext } from "../context/UIContext";
 
-
-const styles = (theme) => ({
+const useStyles = makeStyles((theme) => ({
   root: {
     width: "100vw",
-    background: "",
+    height: "100vh",
+    paddingTop: theme.mixins.toolbar.minHeight,
     flexGrow: 1,
-    transition: "padding 225ms cubic-bezier(0, 0, 0.2, 1) 0ms"
+    transition: "padding 225ms cubic-bezier(0, 0, 0.2, 1) 0ms",
+    overflow: "hidden",
+    [`${theme.breakpoints.up("xs")} and (orientation: landscape)`]: {
+      paddingTop: 54
+    },
+    [`${theme.breakpoints.up("xs")} and (orientation: portrait)`]: {
+      paddingTop: 54
+    },
+    [theme.breakpoints.up("sm")]: {
+      paddingTop: theme.mixins.toolbar.minHeight
+    }
   },
   block: {
     marginBottom: theme.spacing(3)
+  },
+  drawerButton: {
+    borderRadius: 0
   },
   sidebar: {
     flex: "1 1 auto",
@@ -46,16 +59,16 @@ const styles = (theme) => ({
     flex: 1
   },
   leadingDrawerOpen: {
-    ...theme.mixins.leadingPaddingWhenPrimaryDrawerIsOpen
+    paddingLeft: theme.dimensions.drawerWidth
   },
   trailingDrawerOpen: {
-    ...theme.mixins.leadingPaddingWhenPrimaryDrawerIsOpen
+    paddingRight: theme.dimensions.detailDrawerWidth
   },
   drawerPaperAnchorBottom: {
     width: "100%",
-    height: "100%"
+    height: "80%"
   }
-});
+}));
 
 /**
  * Primary/Detail layout
@@ -69,15 +82,14 @@ function ContentViewPrimaryDetailLayout(props) {
     DetailComponent,
     PrimaryComponent,
     children,
-    classes,
     detailBlockRegionName,
-    drawerTitle,
-    isLeadingDrawerOpen,
-    isTrailingDrawerOpen,
+    drawerButtonTitle = "More",
     primaryBlockRegionName,
     ...blockProps
   } = props;
 
+  const classes = useStyles();
+  const { isPrimarySidebarOpen, isDetailDrawerOpen } = useContext(UIContext);
   const isMobile = useMediaQuery("mobile");
 
   const closeDrawer = () => {
@@ -88,25 +100,27 @@ function ContentViewPrimaryDetailLayout(props) {
     <div
       className={
         classNames(classes.root, {
-          [classes.leadingDrawerOpen]: isLeadingDrawerOpen,
-          [classes.trailingDrawerOpen]: isTrailingDrawerOpen
+          [classes.leadingDrawerOpen]: isPrimarySidebarOpen && !isMobile,
+          [classes.trailingDrawerOpen]: isDetailDrawerOpen && !isMobile
         })
       }
     >
       {AppBarComponent}
       {isMobile &&
         <>
-          <Toolbar>
-            <Button
-              fullWidth
-              onClick={() => setDrawerOpen(true)}
-            >
-              {drawerTitle}
-            </Button>
-          </Toolbar>
+          <Button
+            color="default"
+            className={classes.drawerButton}
+            fullWidth
+            onClick={() => setDrawerOpen(true)}
+            variant="contained"
+          >
+            <ChevronDownIcon /> {drawerButtonTitle}
+          </Button>
 
           <Drawer
             anchor="bottom"
+            disableElevation={true}
             classes={{
               paperAnchorBottom: classes.drawerPaperAnchorBottom
             }}
@@ -119,10 +133,13 @@ function ContentViewPrimaryDetailLayout(props) {
               position="sticky"
             >
               <Toolbar>
-                <Typography className={classes.title} variant="h3">{drawerTitle}</Typography>
-                <IconButton onClick={closeDrawer} size="small">
-                  <CloseIcon />
-                </IconButton>
+                <Box display="flex" justifyContent="center" width="100%">
+                  <IconButton
+                    onClick={closeDrawer} size="large"
+                  >
+                    <ChevronDownIcon />
+                  </IconButton>
+                </Box>
               </Toolbar>
             </AppBar>
             {PrimaryComponent || <Blocks region={primaryBlockRegionName} blockProps={blockProps} />}
@@ -150,13 +167,10 @@ ContentViewPrimaryDetailLayout.propTypes = {
   DetailContainerProps: PropTypes.object,
   PrimaryComponent: PropTypes.node,
   children: PropTypes.node,
-  classes: PropTypes.object,
   detailBlockRegionName: PropTypes.string,
-  drawerTitle: PropTypes.string.isRequired,
-  isLeadingDrawerOpen: PropTypes.bool,
+  drawerButtonTitle: PropTypes.string.isRequired,
   isMobile: PropTypes.bool,
-  isTrailingDrawerOpen: PropTypes.bool,
   primaryBlockRegionName: PropTypes.string
 };
 
-export default withStyles(styles, { name: "RuiContentViewPrimaryDetailLayout" })(ContentViewPrimaryDetailLayout);
+export default ContentViewPrimaryDetailLayout;

--- a/imports/client/ui/layouts/ContentViewPrimaryDetailLayout.js
+++ b/imports/client/ui/layouts/ContentViewPrimaryDetailLayout.js
@@ -1,0 +1,162 @@
+/**
+ * Component provides a regions for a primary (sidebar) and detail view
+ */
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import classNames from "classnames";
+import withStyles from "@material-ui/core/styles/withStyles";
+import Button from "@reactioncommerce/catalyst/Button";
+import { Blocks } from "@reactioncommerce/reaction-components";
+import {
+  AppBar,
+  Box,
+  Drawer,
+  Toolbar,
+  IconButton,
+  Typography
+} from "@material-ui/core";
+import CloseIcon from "mdi-material-ui/Close";
+import useMediaQuery from "../hooks/useMediaQuery";
+
+
+const styles = (theme) => ({
+  root: {
+    width: "100vw",
+    background: "",
+    flexGrow: 1,
+    transition: "padding 225ms cubic-bezier(0, 0, 0.2, 1) 0ms"
+  },
+  block: {
+    marginBottom: theme.spacing(3)
+  },
+  sidebar: {
+    flex: "1 1 auto",
+    maxWidth: 330,
+    height: `calc(100vh - ${theme.mixins.toolbar.minHeight}px)`,
+    overflowY: "auto",
+    borderRight: `1px solid ${theme.palette.divider}`
+  },
+  content: {
+    flex: "1 1 auto",
+    height: `calc(100vh - ${theme.mixins.toolbar.minHeight}px)`,
+    overflowY: "auto",
+    paddingTop: theme.spacing(5)
+  },
+  title: {
+    flex: 1
+  },
+  leadingDrawerOpen: {
+    ...theme.mixins.leadingPaddingWhenPrimaryDrawerIsOpen
+  },
+  trailingDrawerOpen: {
+    ...theme.mixins.leadingPaddingWhenPrimaryDrawerIsOpen
+  },
+  drawerPaperAnchorBottom: {
+    width: "100%",
+    height: "100%"
+  }
+});
+
+/**
+ * Primary/Detail layout
+ * @param {Object} props ComponentProps
+ * @returns {React.ReactElement} A react element representing the primary/detail layout
+ */
+function ContentViewPrimaryDetailLayout(props) {
+  const [isDrawerOpen, setDrawerOpen] = useState(false);
+  const {
+    AppBarComponent,
+    DetailComponent,
+    PrimaryComponent,
+    children,
+    classes,
+    detailBlockRegionName,
+    drawerTitle,
+    isLeadingDrawerOpen,
+    isTrailingDrawerOpen,
+    primaryBlockRegionName,
+    ...blockProps
+  } = props;
+
+  const isMobile = useMediaQuery("mobile");
+
+  const closeDrawer = () => {
+    setDrawerOpen(false);
+  };
+
+  return (
+    <div
+      className={
+        classNames(classes.root, {
+          [classes.leadingDrawerOpen]: isLeadingDrawerOpen,
+          [classes.trailingDrawerOpen]: isTrailingDrawerOpen
+        })
+      }
+    >
+      {AppBarComponent}
+      {isMobile &&
+        <>
+          <Toolbar>
+            <Button
+              fullWidth
+              onClick={() => setDrawerOpen(true)}
+            >
+              {drawerTitle}
+            </Button>
+          </Toolbar>
+
+          <Drawer
+            anchor="bottom"
+            classes={{
+              paperAnchorBottom: classes.drawerPaperAnchorBottom
+            }}
+            open={isDrawerOpen}
+            onClose={closeDrawer}
+          >
+            <AppBar
+              color="default"
+              elevation={0}
+              position="sticky"
+            >
+              <Toolbar>
+                <Typography className={classes.title} variant="h3">{drawerTitle}</Typography>
+                <IconButton onClick={closeDrawer} size="small">
+                  <CloseIcon />
+                </IconButton>
+              </Toolbar>
+            </AppBar>
+            {PrimaryComponent || <Blocks region={primaryBlockRegionName} blockProps={blockProps} />}
+          </Drawer>
+        </>
+      }
+      <Box display="flex">
+        {!isMobile &&
+          <div className={classes.sidebar}>
+            {PrimaryComponent || <Blocks region={primaryBlockRegionName} blockProps={blockProps} />}
+          </div>
+        }
+
+        <div className={classes.content}>
+          {DetailComponent || <Blocks region={detailBlockRegionName} blockProps={blockProps} />}
+        </div>
+      </Box>
+    </div>
+  );
+}
+
+ContentViewPrimaryDetailLayout.propTypes = {
+  AppBarComponent: PropTypes.node,
+  DetailComponent: PropTypes.node,
+  DetailContainerProps: PropTypes.object,
+  PrimaryComponent: PropTypes.node,
+  children: PropTypes.node,
+  classes: PropTypes.object,
+  detailBlockRegionName: PropTypes.string,
+  drawerTitle: PropTypes.string.isRequired,
+  isLeadingDrawerOpen: PropTypes.bool,
+  isMobile: PropTypes.bool,
+  isTrailingDrawerOpen: PropTypes.bool,
+  primaryBlockRegionName: PropTypes.string
+};
+
+export default withStyles(styles, { name: "RuiContentViewPrimaryDetailLayout" })(ContentViewPrimaryDetailLayout);

--- a/imports/client/ui/layouts/ContentViewPrimaryDetailLayout.js
+++ b/imports/client/ui/layouts/ContentViewPrimaryDetailLayout.js
@@ -134,9 +134,7 @@ function ContentViewPrimaryDetailLayout(props) {
             >
               <Toolbar>
                 <Box display="flex" justifyContent="center" width="100%">
-                  <IconButton
-                    onClick={closeDrawer} size="large"
-                  >
+                  <IconButton onClick={closeDrawer}>
                     <ChevronDownIcon />
                   </IconButton>
                 </Box>

--- a/imports/client/ui/layouts/ContentViewPrimaryDetailLayout.js
+++ b/imports/client/ui/layouts/ContentViewPrimaryDetailLayout.js
@@ -110,6 +110,7 @@ function ContentViewPrimaryDetailLayout(props) {
         <>
           <Button
             color="default"
+            disableElevation={true}
             className={classes.drawerButton}
             fullWidth
             onClick={() => setDrawerOpen(true)}
@@ -120,7 +121,6 @@ function ContentViewPrimaryDetailLayout(props) {
 
           <Drawer
             anchor="bottom"
-            disableElevation={true}
             classes={{
               paperAnchorBottom: classes.drawerPaperAnchorBottom
             }}

--- a/imports/client/ui/layouts/Dashboard.js
+++ b/imports/client/ui/layouts/Dashboard.js
@@ -58,7 +58,7 @@ function Dashboard(props) {
   const contextValue = useMemo(() => ({
     isDetailDrawerOpen,
     isMobile,
-    isPrimarySidebarOpen,
+    isPrimarySidebarOpen: (isMobile && isPrimarySidebarOpen) || true,
     onClosePrimarySidebar,
     onTogglePrimarySidebar,
     onCloseDetailDrawer,

--- a/imports/client/ui/layouts/Dashboard.js
+++ b/imports/client/ui/layouts/Dashboard.js
@@ -1,23 +1,18 @@
-import React, { Component } from "react";
+import React, { useMemo, useState } from "react";
 import PropTypes from "prop-types";
-import Helmet from "react-helmet";
-import { i18next } from "/client/api";
-import { compose } from "recompose";
-import withStyles from "@material-ui/core/styles/withStyles";
-import withWidth, { isWidthDown } from "@material-ui/core/withWidth";
 import { CustomPropTypes } from "@reactioncommerce/components/utils";
 import { withComponents } from "@reactioncommerce/components-context";
-import { Route, Switch } from "react-router";
-import { withRouter } from "react-router-dom";
+import { makeStyles } from "@material-ui/core";
 import PrimaryAppBar from "../components/PrimaryAppBar/PrimaryAppBar";
 import ProfileImageWithData from "../components/ProfileImageWithData";
 import Sidebar from "../components/Sidebar";
 import { operatorRoutes } from "../index";
 import { UIContext } from "../context/UIContext";
-import ContentViewFullLayout from "./ContentViewFullLayout";
-import ContentViewStandardLayout from "./ContentViewStandardLayout";
+import useOperatorRoutes from "../hooks/useOperatorRoutes";
+import useMediaQuery from "../hooks/useMediaQuery";
+import OperatorRoutes from "./OperatorRoutes";
 
-const styles = (theme) => ({
+const useStyles = makeStyles((theme) => ({
   "@global": {
     html: {
       // Remove the 10px fontSize from the html element as it affects fonts that rely on rem
@@ -30,150 +25,79 @@ const styles = (theme) => ({
   "leftSidebarOpen": {
     ...theme.mixins.leadingPaddingWhenPrimaryDrawerIsOpen
   }
-});
+}));
 
-class Dashboard extends Component {
-  static propTypes = {
-    classes: PropTypes.object,
-    components: PropTypes.shape({
-      IconHamburger: CustomPropTypes.component.isRequired
-    }),
-    location: PropTypes.object,
-    logout: PropTypes.func,
-    viewer: PropTypes.object,
-    width: PropTypes.string
+/**
+ * Main dashboard layout
+ * @param {Object} props Component props
+ * @returns {React.ReactElement} A react element representing the main dashboard
+ */
+function Dashboard(props) {
+  const { logout, viewer } = props;
+  const classes = useStyles();
+  const isMobile = useMediaQuery("mobile");
+  const routes = useOperatorRoutes({ group: "main" });
+  const [isDetailDrawerOpen, setDetailDrawerOpen] = useState(false);
+  const [isPrimarySidebarOpen, setPrimarySidebarOpen] = useState(true);
+
+  const onTogglePrimarySidebar = () => {
+    setPrimarySidebarOpen((prevValue) => !prevValue);
   };
 
-  constructor(props) {
-    super(props);
-
-    // State also contains the updater function so it will
-    // be passed down into the context provider
-    this.state = {
-      isDetailDrawerOpen: false,
-      isMobile: false,
-      isPrimarySidebarOpen: true,
-      onClosePrimarySidebar: this.onClosePrimarySidebar,
-      onTogglePrimarySidebar: this.onTogglePrimarySidebar,
-      onCloseDetailDrawer: this.onCloseDetailDrawer,
-      onToggleDetailDrawer: this.onToggleDetailDrawer
-    };
-  }
-
-  componentDidUpdate(prevProps, prevState) {
-    const { width, location } = this.props;
-    const isMobile = isWidthDown("sm", width);
-
-    if (prevState.isMobile !== isMobile) {
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({
-        isMobile
-      });
-    }
-
-    if (!isMobile && prevState.isPrimarySidebarOpen === false) {
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({
-        isPrimarySidebarOpen: true
-      });
-    }
-
-    // Close the detail drawer on route change
-    if (location.pathname !== prevProps.location.pathname) {
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({
-        isDetailDrawerOpen: false
-      });
-    }
-  }
-
-  onTogglePrimarySidebar = () => {
-    this.setState((state) => ({
-      isPrimarySidebarOpen: !state.isPrimarySidebarOpen
-    }));
+  const onToggleDetailDrawer = () => {
+    setDetailDrawerOpen((prevValue) => !prevValue);
   };
 
-  onToggleDetailDrawer = () => {
-    this.setState((state) => ({
-      isDetailDrawerOpen: !state.isDetailDrawerOpen
-    }));
+  const onCloseDetailDrawer = () => {
+    setDetailDrawerOpen(false);
   };
 
-  onCloseDetailDrawer = () => {
-    this.setState({ isDetailDrawerOpen: false });
+  const onClosePrimarySidebar = () => {
+    setPrimarySidebarOpen(false);
   };
 
-  onClosePrimarySidebar = () => {
-    this.setState({ isPrimarySidebarOpen: false });
-  };
+  const contextValue = useMemo(() => ({
+    isDetailDrawerOpen,
+    isMobile,
+    isPrimarySidebarOpen,
+    onClosePrimarySidebar,
+    onTogglePrimarySidebar,
+    onCloseDetailDrawer,
+    onToggleDetailDrawer,
+    setDetailDrawerOpen,
+    setPrimarySidebarOpen
+  }), [isDetailDrawerOpen, isMobile, isPrimarySidebarOpen]);
 
-  render() {
-    const { classes, logout, viewer, width } = this.props;
-    const { isDetailDrawerOpen, isPrimarySidebarOpen } = this.state;
-    const isMobile = isWidthDown("sm", width);
-
-    return (
-      <UIContext.Provider value={this.state}>
-        <div className={classes.container}>
-          <PrimaryAppBar>
-            <ProfileImageWithData logout={logout} size={40} viewer={viewer} />
-          </PrimaryAppBar>
-          <Sidebar
-            isMobile={isMobile}
-            isSidebarOpen={isPrimarySidebarOpen && !isDetailDrawerOpen}
-            setIsSidebarOpen={(value) => {
-              this.setState({ isPrimarySidebarOpen: value });
-            }}
-            onDrawerClose={this.state.onClosePrimarySidebar}
-            routes={operatorRoutes}
-          />
-          <Switch>
-            {
-              operatorRoutes.map((route) => (
-                <Route
-                  exact
-                  key={route.path}
-                  path={route.path}
-                  render={(props) => {
-                    const title = i18next.t(route.sidebarI18nLabel, { defaultValue: "Reaction Admin" });
-                    // If the layout component is explicitly null
-                    if (route.layoutComponent === null) {
-                      return (
-                        <ContentViewFullLayout
-                          isLeadingDrawerOpen={!isMobile}
-                          isTrailingDrawerOpen={isDetailDrawerOpen && !isMobile}
-                        >
-                          <Helmet title={title} />
-                          <route.mainComponent uiState={this.state} {...props} />
-                        </ContentViewFullLayout>
-                      );
-                    }
-
-                    const LayoutComponent = route.layoutComponent || ContentViewStandardLayout;
-
-                    return (
-                      <LayoutComponent
-                        isLeadingDrawerOpen={!isMobile}
-                        isTrailingDrawerOpen={isDetailDrawerOpen && !isMobile}
-                      >
-                        <Helmet title={title} />
-                        <route.mainComponent uiState={this.state} {...props} />
-                      </LayoutComponent>
-                    );
-                  }}
-                />
-              ))
-            }
-          </Switch>
-        </div>
-      </UIContext.Provider>
-    );
-  }
+  return (
+    <UIContext.Provider value={contextValue}>
+      <div className={classes.container}>
+        <PrimaryAppBar>
+          <ProfileImageWithData logout={logout} size={40} viewer={viewer} />
+        </PrimaryAppBar>
+        <Sidebar
+          isMobile={isMobile}
+          isSidebarOpen={isPrimarySidebarOpen}
+          setIsSidebarOpen={(value) => {
+            setPrimarySidebarOpen(value);
+          }}
+          onDrawerClose={onClosePrimarySidebar}
+          routes={operatorRoutes}
+        />
+        <OperatorRoutes routes={routes} />
+      </div>
+    </UIContext.Provider>
+  );
 }
 
-export default compose(
-  withComponents,
-  withRouter,
-  withWidth({ initialWidth: "md" }),
-  withStyles(styles, { name: "RuiDashboard" })
-)(Dashboard);
+Dashboard.propTypes = {
+  classes: PropTypes.object,
+  components: PropTypes.shape({
+    IconHamburger: CustomPropTypes.component.isRequired
+  }),
+  location: PropTypes.object,
+  logout: PropTypes.func,
+  viewer: PropTypes.object,
+  width: PropTypes.string
+};
+
+export default withComponents(Dashboard);

--- a/imports/client/ui/layouts/Dashboard.js
+++ b/imports/client/ui/layouts/Dashboard.js
@@ -6,7 +6,6 @@ import { makeStyles } from "@material-ui/core";
 import PrimaryAppBar from "../components/PrimaryAppBar/PrimaryAppBar";
 import ProfileImageWithData from "../components/ProfileImageWithData";
 import Sidebar from "../components/Sidebar";
-import { operatorRoutes } from "../index";
 import { UIContext } from "../context/UIContext";
 import useOperatorRoutes from "../hooks/useOperatorRoutes";
 import useMediaQuery from "../hooks/useMediaQuery";
@@ -81,7 +80,6 @@ function Dashboard(props) {
             setPrimarySidebarOpen(value);
           }}
           onDrawerClose={onClosePrimarySidebar}
-          routes={operatorRoutes}
         />
         <OperatorRoutes routes={routes} />
       </div>

--- a/imports/client/ui/layouts/Dashboard.js
+++ b/imports/client/ui/layouts/Dashboard.js
@@ -36,7 +36,7 @@ function Dashboard(props) {
   const { logout, viewer } = props;
   const classes = useStyles();
   const isMobile = useMediaQuery("mobile");
-  const routes = useOperatorRoutes({ group: "main" });
+  const routes = useOperatorRoutes();
   const [isDetailDrawerOpen, setDetailDrawerOpen] = useState(false);
   const [isPrimarySidebarOpen, setPrimarySidebarOpen] = useState(true);
 

--- a/imports/client/ui/layouts/Dashboard.js
+++ b/imports/client/ui/layouts/Dashboard.js
@@ -81,7 +81,10 @@ function Dashboard(props) {
           }}
           onDrawerClose={onClosePrimarySidebar}
         />
-        <OperatorRoutes routes={routes} />
+        <OperatorRoutes
+          isExactMatch={true}
+          routes={routes}
+        />
       </div>
     </UIContext.Provider>
   );

--- a/imports/client/ui/layouts/OperatorRoutes.js
+++ b/imports/client/ui/layouts/OperatorRoutes.js
@@ -12,42 +12,55 @@ import ContentViewStandardLayout from "./ContentViewStandardLayout";
  * @param {Object} props ComponentProps
  * @returns {Object} An object containing filtered routes
  */
-function OperatorRoutes({ LayoutComponent: LayoutComponentProp, routes }) {
+function OperatorRoutes({
+  DefaultLayoutComponent = ContentViewStandardLayout,
+  isExactMatch,
+  routes
+}) {
   const isMobile = useMediaQuery("mobile");
   const uiContext = useContext(UIContext);
 
   return (
     <Switch>
-      {routes.map((route) => {
-        const LayoutComponent = LayoutComponentProp || route.LayoutComponent || ContentViewStandardLayout;
+      {routes.map((route) => (
+        <Route
+          exact={isExactMatch}
+          key={route.path}
+          path={route.path}
+          render={(routeProps) => {
+            const title = i18next.t(route.sidebarI18nLabel, { defaultValue: "Reaction Admin" });
 
-        return (
-          <Route
-            key={route.path}
-            path={route.path}
-            render={(routeProps) => {
-              const title = i18next.t(route.sidebarI18nLabel, { defaultValue: "Reaction Admin" });
-
+            if (route.LayoutComponent === null) {
               return (
-                <LayoutComponent
-                  isLeadingDrawerOpen={!isMobile}
-                  isTrailingDrawerOpen={uiContext.isDetailDrawerOpen && !isMobile}
-                >
+                <>
                   <Helmet title={title} />
                   <route.MainComponent uiState={this.state} {...routeProps} />
-                </LayoutComponent>
+                </>
               );
-            }}
-            {...route.props}
-          />
-        );
-      })}
+            }
+
+            const LayoutComponent = route.LayoutComponent || DefaultLayoutComponent;
+
+            return (
+              <LayoutComponent
+                isLeadingDrawerOpen={!isMobile}
+                isTrailingDrawerOpen={uiContext.isDetailDrawerOpen && !isMobile}
+              >
+                <Helmet title={title} />
+                <route.MainComponent uiState={this.state} {...routeProps} />
+              </LayoutComponent>
+            );
+          }}
+          {...route.props}
+        />
+      ))}
     </Switch>
   );
 }
 
 OperatorRoutes.propTypes = {
-  LayoutComponent: PropTypes.element,
+  DefaultLayoutComponent: PropTypes.element,
+  isExactMatch: PropTypes.bool,
   routes: PropTypes.arrayOf(PropTypes.shape({
     path: PropTypes.string,
     props: PropTypes.object

--- a/imports/client/ui/layouts/OperatorRoutes.js
+++ b/imports/client/ui/layouts/OperatorRoutes.js
@@ -1,0 +1,57 @@
+import React, { useContext } from "react";
+import PropTypes from "prop-types";
+import { Switch, Route } from "react-router";
+import Helmet from "react-helmet";
+import i18next from "i18next";
+import { UIContext } from "../context/UIContext";
+import useMediaQuery from "../hooks/useMediaQuery";
+import ContentViewStandardLayout from "./ContentViewStandardLayout";
+
+/**
+ * Operator routes
+ * @param {Object} props ComponentProps
+ * @returns {Object} An object containing filtered routes
+ */
+function OperatorRoutes({ LayoutComponent: LayoutComponentProp, routes }) {
+  const isMobile = useMediaQuery("mobile");
+  const uiContext = useContext(UIContext);
+
+  return (
+    <Switch>
+      {routes.map((route) => {
+        const LayoutComponent = LayoutComponentProp || route.LayoutComponent || ContentViewStandardLayout;
+
+        return (
+          <Route
+            key={route.path}
+            path={route.path}
+            render={(routeProps) => {
+              const title = i18next.t(route.sidebarI18nLabel, { defaultValue: "Reaction Admin" });
+
+              return (
+                <LayoutComponent
+                  isLeadingDrawerOpen={!isMobile}
+                  isTrailingDrawerOpen={uiContext.isDetailDrawerOpen && !isMobile}
+                >
+                  <Helmet title={title} />
+                  <route.MainComponent uiState={this.state} {...routeProps} />
+                </LayoutComponent>
+              );
+            }}
+            {...route.props}
+          />
+        );
+      })}
+    </Switch>
+  );
+}
+
+OperatorRoutes.propTypes = {
+  LayoutComponent: PropTypes.element,
+  routes: PropTypes.arrayOf(PropTypes.shape({
+    path: PropTypes.string,
+    props: PropTypes.object
+  }))
+};
+
+export default OperatorRoutes;

--- a/imports/client/ui/layouts/OperatorRoutes.js
+++ b/imports/client/ui/layouts/OperatorRoutes.js
@@ -34,7 +34,7 @@ function OperatorRoutes({
               return (
                 <>
                   <Helmet title={title} />
-                  <route.MainComponent uiState={this.state} {...routeProps} />
+                  <route.MainComponent {...routeProps} />
                 </>
               );
             }
@@ -47,7 +47,7 @@ function OperatorRoutes({
                 isTrailingDrawerOpen={uiContext.isDetailDrawerOpen && !isMobile}
               >
                 <Helmet title={title} />
-                <route.MainComponent uiState={this.state} {...routeProps} />
+                <route.MainComponent {...routeProps} />
               </LayoutComponent>
             );
           }}

--- a/imports/plugins/core/accounts/client/index.js
+++ b/imports/plugins/core/accounts/client/index.js
@@ -24,7 +24,7 @@ import "./templates/profile/profile.html";
 import "./templates/profile/profile.js";
 
 registerOperatorRoute({
-  group: "main",
+  group: "navigation",
   path: "/accounts",
   priority: 40,
   MainComponent: Accounts,

--- a/imports/plugins/core/accounts/client/index.js
+++ b/imports/plugins/core/accounts/client/index.js
@@ -24,19 +24,16 @@ import "./templates/profile/profile.html";
 import "./templates/profile/profile.js";
 
 registerOperatorRoute({
-  isNavigationLink: true,
-  isSetting: false,
+  group: "main",
   path: "/accounts",
   priority: 40,
-  mainComponent: Accounts,
+  MainComponent: Accounts,
   // eslint-disable-next-line react/display-name, react/no-multi-comp
   SidebarIconComponent: (props) => <AccountIcon {...props} />,
   sidebarI18nLabel: "admin.dashboard.accountsLabel"
 });
 
 registerOperatorRoute({
-  isNavigationLink: false,
-  isSetting: false,
   path: "/profile",
-  mainComponent: "accountProfile"
+  MainComponent: "accountProfile"
 });

--- a/imports/plugins/core/address/client/index.js
+++ b/imports/plugins/core/address/client/index.js
@@ -2,9 +2,8 @@ import { registerOperatorRoute } from "/imports/client/ui";
 import ShopAddressValidationSettings from "./containers/ShopAddressValidationSettings";
 
 registerOperatorRoute({
-  isNavigationLink: true,
-  isSetting: true,
-  mainComponent: ShopAddressValidationSettings,
+  group: "settings",
+  MainComponent: ShopAddressValidationSettings,
   path: "/address-validation-settings",
   priority: 900,
   sidebarI18nLabel: "addressValidation.title"

--- a/imports/plugins/core/dashboard/client/index.js
+++ b/imports/plugins/core/dashboard/client/index.js
@@ -20,27 +20,23 @@ import "./templates/shop/settings/settings.js";
 
 // Default landing page
 registerOperatorRoute({
-  isNavigationLink: false,
-  isSetting: false,
   path: "/",
-  mainComponent: OperatorLanding
+  MainComponent: OperatorLanding
 });
 
 registerOperatorRoute({
-  isNavigationLink: true,
-  isSetting: true,
+  group: "settings",
   priority: 10,
   path: "/shop-settings",
-  mainComponent: "shopSettings",
+  MainComponent: "shopSettings",
   // eslint-disable-next-line react/display-name
   SidebarIconComponent: (props) => <FontAwesomeIcon icon={faStore} {...props} />,
   sidebarI18nLabel: "admin.settings.shopSettingsLabel"
 });
 
 registerOperatorRoute({
-  isNavigationLink: true,
-  isSetting: true,
-  mainComponent: SystemInformation,
+  group: "settings",
+  MainComponent: SystemInformation,
   path: "/system",
   priority: 1000,
   sidebarI18nLabel: "shopSettings.systemInfo.title"

--- a/imports/plugins/core/discounts/client/index.js
+++ b/imports/plugins/core/discounts/client/index.js
@@ -5,7 +5,7 @@ import { registerOperatorRoute } from "/imports/client/ui";
 import DiscountsPage from "./DiscountsPage.js";
 
 registerOperatorRoute({
-  group: "main",
+  group: "navigation",
   priority: 60,
   path: "/discounts",
   MainComponent: DiscountsPage,

--- a/imports/plugins/core/discounts/client/index.js
+++ b/imports/plugins/core/discounts/client/index.js
@@ -5,10 +5,10 @@ import { registerOperatorRoute } from "/imports/client/ui";
 import DiscountsPage from "./DiscountsPage.js";
 
 registerOperatorRoute({
-  isNavigationLink: true,
+  group: "main",
   priority: 60,
   path: "/discounts",
-  mainComponent: DiscountsPage,
+  MainComponent: DiscountsPage,
   // eslint-disable-next-line react/display-name
   SidebarIconComponent: (props) => <FontAwesomeIcon icon={faPercent} {...props} />,
   sidebarI18nLabel: "admin.shortcut.discountsLabel"

--- a/imports/plugins/core/email/client/index.js
+++ b/imports/plugins/core/email/client/index.js
@@ -6,10 +6,9 @@ import { registerOperatorRoute } from "/imports/client/ui";
 import EmailSettings from "./containers/EmailSettings";
 
 registerOperatorRoute({
-  isNavigationLink: true,
-  isSetting: true,
+  group: "settings",
   path: "/email",
-  mainComponent: EmailSettings,
+  MainComponent: EmailSettings,
   // eslint-disable-next-line react/display-name
   SidebarIconComponent: (props) => <FontAwesomeIcon icon={faEnvelope} {...props} />,
   sidebarI18nLabel: "admin.dashboard.emailLabel"

--- a/imports/plugins/core/i18n/client/index.js
+++ b/imports/plugins/core/i18n/client/index.js
@@ -8,9 +8,8 @@ import Localization from "./containers/localizationSettings";
 export { default as LocalizationSettings } from "./containers/localizationSettings";
 
 registerOperatorRoute({
-  isNavigationLink: true,
-  isSetting: true,
-  mainComponent: Localization,
+  group: "settings",
+  MainComponent: Localization,
   path: "/localization",
   // eslint-disable-next-line react/display-name
   SidebarIconComponent: (props) => <FontAwesomeIcon icon={faGlobe} {...props} />,

--- a/imports/plugins/core/navigation/client/components/NavigationDashboard.js
+++ b/imports/plugins/core/navigation/client/components/NavigationDashboard.js
@@ -20,9 +20,6 @@ class NavigationDashboard extends Component {
     onSetSortableNavigationTree: PropTypes.func,
     shopId: PropTypes.string,
     sortableNavigationTree: PropTypes.arrayOf(PropTypes.object),
-    uiState: PropTypes.shape({
-      isLeftDrawerOpen: PropTypes.bool
-    }),
     updateNavigationItem: PropTypes.func,
     updateNavigationTree: PropTypes.func
   }

--- a/imports/plugins/core/navigation/client/components/NavigationDashboard.js
+++ b/imports/plugins/core/navigation/client/components/NavigationDashboard.js
@@ -1,30 +1,14 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import Dialog from "@material-ui/core/Dialog";
-import DialogContent from "@material-ui/core/DialogContent";
-import Button from "@material-ui/core/Button";
-import { withStyles } from "@material-ui/core/styles";
+import { Dialog, DialogContent } from "@material-ui/core";
+import Button from "@reactioncommerce/catalyst/Button";
 import HTML5Backend from "react-dnd-html5-backend";
 import { DragDropContext } from "react-dnd";
 import NavigationItemForm from "./NavigationItemForm";
 import NavigationTreeContainer from "./NavigationTreeContainer";
 import NavigationItemList from "./NavigationItemList";
 import PrimaryAppBar from "/imports/client/ui/components/PrimaryAppBar";
-
-
-const styles = (theme) => ({
-  root: {
-    display: "flex",
-    height: `calc(100vh - ${theme.mixins.toolbar.minHeight}px)`,
-    overflow: "hidden"
-  },
-  leftSidebarOpen: {
-    ...theme.mixins.leadingPaddingWhenPrimaryDrawerIsOpen
-  },
-  title: {
-    flex: 1
-  }
-});
+import ContentViewPrimaryDetailLayout from "/imports/client/ui/layouts/ContentViewPrimaryDetailLayout";
 
 class NavigationDashboard extends Component {
   static propTypes = {
@@ -93,7 +77,6 @@ class NavigationDashboard extends Component {
 
   render() {
     const {
-      classes,
       createNavigationItem,
       deleteNavigationItem,
       navigationItems,
@@ -113,20 +96,28 @@ class NavigationDashboard extends Component {
     } = this.state;
 
     return (
-      <div className={classes.root}>
-        <PrimaryAppBar title="Main Navigation">
-          <Button color="primary" onClick={onDiscardNavigationTreeChanges}>Discard</Button>
-          <Button color="primary" variant="contained" onClick={updateNavigationTree}>Save Changes</Button>
-        </PrimaryAppBar>
-        <NavigationItemList
-          onClickAddNavigationItem={this.addNavigationItem}
-          navigationItems={navigationItems}
-          onClickUpdateNavigationItem={this.updateNavigationItem}
-        />
-        <NavigationTreeContainer
-          sortableNavigationTree={sortableNavigationTree}
-          onSetSortableNavigationTree={onSetSortableNavigationTree}
-          onClickUpdateNavigationItem={this.updateNavigationItem}
+      <>
+        <ContentViewPrimaryDetailLayout
+          AppBarComponent={
+            <PrimaryAppBar title="Main Navigation">
+              <Button color="primary" onClick={onDiscardNavigationTreeChanges}>Discard</Button>
+              <Button color="primary" variant="contained" onClick={updateNavigationTree}>Save Changes</Button>
+            </PrimaryAppBar>
+          }
+          PrimaryComponent={
+            <NavigationItemList
+              onClickAddNavigationItem={this.addNavigationItem}
+              navigationItems={navigationItems}
+              onClickUpdateNavigationItem={this.updateNavigationItem}
+            />
+          }
+          DetailComponent={
+            <NavigationTreeContainer
+              sortableNavigationTree={sortableNavigationTree}
+              onSetSortableNavigationTree={onSetSortableNavigationTree}
+              onClickUpdateNavigationItem={this.updateNavigationItem}
+            />
+          }
         />
         <Dialog
           aria-labelledby="simple-modal-title"
@@ -150,9 +141,9 @@ class NavigationDashboard extends Component {
             />
           </DialogContent>
         </Dialog>
-      </div>
+      </>
     );
   }
 }
 
-export default DragDropContext(HTML5Backend)(withStyles(styles)(NavigationDashboard));
+export default DragDropContext(HTML5Backend)(NavigationDashboard);

--- a/imports/plugins/core/navigation/client/components/NavigationItemList.js
+++ b/imports/plugins/core/navigation/client/components/NavigationItemList.js
@@ -11,7 +11,10 @@ const styles = (theme) => ({
     flexDirection: "column",
     flexGrow: 1,
     width: "100%",
-    maxWidth: 380
+    maxWidth: 380,
+    [theme.breakpoints.up("sm")]: {
+      maxWidth: "100%"
+    }
   },
   header: {
     padding: theme.spacing(2),

--- a/imports/plugins/core/navigation/client/components/NavigationItemList.js
+++ b/imports/plugins/core/navigation/client/components/NavigationItemList.js
@@ -12,7 +12,7 @@ const styles = (theme) => ({
     flexGrow: 1,
     width: "100%",
     maxWidth: 380,
-    [theme.breakpoints.up("sm")]: {
+    [theme.breakpoints.up("xs")]: {
       maxWidth: "100%"
     }
   },

--- a/imports/plugins/core/navigation/client/components/NavigationTreeContainer.js
+++ b/imports/plugins/core/navigation/client/components/NavigationTreeContainer.js
@@ -12,7 +12,6 @@ import SortableTheme from "./SortableTheme";
 const styles = (theme) => ({
   wrapper: {
     width: "100%",
-    borderLeft: `1px solid ${theme.palette.divider}`,
     height: `calc(100vh - ${theme.mixins.toolbar.minHeight}px)`
   }
 });

--- a/imports/plugins/core/navigation/client/index.js
+++ b/imports/plugins/core/navigation/client/index.js
@@ -2,14 +2,14 @@
 import React from "react";
 import LinkIcon from "mdi-material-ui/LinkVariant";
 import { registerOperatorRoute } from "/imports/client/ui";
-import ContentViewFullLayout from "/imports/client/ui/layouts/ContentViewFullLayout";
 import NavigationDashboard from "./containers/navigationDashboardContainer";
 import "./containers";
 
 registerOperatorRoute({
   group: "navigation",
   priority: 50,
-  LayoutComponent: ContentViewFullLayout,
+  // Use no layout. NavigationDashboard uses ContentViewPrimaryDetailLayout inside itself.
+  LayoutComponent: null,
   MainComponent: NavigationDashboard,
   path: "/navigation",
   // eslint-disable-next-line react/display-name

--- a/imports/plugins/core/navigation/client/index.js
+++ b/imports/plugins/core/navigation/client/index.js
@@ -7,7 +7,7 @@ import NavigationDashboard from "./containers/navigationDashboardContainer";
 import "./containers";
 
 registerOperatorRoute({
-  group: "main",
+  group: "navigation",
   priority: 50,
   LayoutComponent: ContentViewFullLayout,
   MainComponent: NavigationDashboard,

--- a/imports/plugins/core/navigation/client/index.js
+++ b/imports/plugins/core/navigation/client/index.js
@@ -2,16 +2,16 @@
 import React from "react";
 import LinkIcon from "mdi-material-ui/LinkVariant";
 import { registerOperatorRoute } from "/imports/client/ui";
+import ContentViewFullLayout from "/imports/client/ui/layouts/ContentViewFullLayout";
 import NavigationDashboard from "./containers/navigationDashboardContainer";
-
 import "./containers";
 
 registerOperatorRoute({
   isNavigationLink: true,
   isSetting: false,
   priority: 50,
-  layoutComponent: null,
-  mainComponent: NavigationDashboard,
+  LayoutComponent: ContentViewFullLayout,
+  MainComponent: NavigationDashboard,
   path: "/navigation",
   // eslint-disable-next-line react/display-name
   SidebarIconComponent: (props) => <LinkIcon {...props} />,

--- a/imports/plugins/core/navigation/client/index.js
+++ b/imports/plugins/core/navigation/client/index.js
@@ -7,8 +7,7 @@ import NavigationDashboard from "./containers/navigationDashboardContainer";
 import "./containers";
 
 registerOperatorRoute({
-  isNavigationLink: true,
-  isSetting: false,
+  group: "main",
   priority: 50,
   LayoutComponent: ContentViewFullLayout,
   MainComponent: NavigationDashboard,

--- a/imports/plugins/core/orders/client/index.js
+++ b/imports/plugins/core/orders/client/index.js
@@ -23,7 +23,7 @@ Shop.extend({
  * Single order page route
  */
 registerOperatorRoute({
-    MainComponent: Order,
+  MainComponent: Order,
   path: "/orders/:_id"
 });
 
@@ -31,7 +31,7 @@ registerOperatorRoute({
  * Single order print layout route
  */
 registerOperatorRoute({
-    MainComponent: OrderPrint,
+  MainComponent: OrderPrint,
   path: "/orders/print/:_id"
 });
 

--- a/imports/plugins/core/orders/client/index.js
+++ b/imports/plugins/core/orders/client/index.js
@@ -23,8 +23,7 @@ Shop.extend({
  * Single order page route
  */
 registerOperatorRoute({
-  isNavigationLink: false,
-  mainComponent: Order,
+    MainComponent: Order,
   path: "/orders/:_id"
 });
 
@@ -32,8 +31,7 @@ registerOperatorRoute({
  * Single order print layout route
  */
 registerOperatorRoute({
-  isNavigationLink: false,
-  mainComponent: OrderPrint,
+    MainComponent: OrderPrint,
   path: "/orders/print/:_id"
 });
 
@@ -41,11 +39,10 @@ registerOperatorRoute({
  * Orders table route
  */
 registerOperatorRoute({
-  isNavigationLink: true,
-  isSetting: false,
+  group: "main",
   priority: 10,
-  layoutComponent: ContentViewExtraWideLayout,
-  mainComponent: Orders,
+  LayoutComponent: ContentViewExtraWideLayout,
+  MainComponent: Orders,
   path: "/orders",
   // eslint-disable-next-line react/display-name
   SidebarIconComponent: (props) => <InboxIcon {...props} />,

--- a/imports/plugins/core/orders/client/index.js
+++ b/imports/plugins/core/orders/client/index.js
@@ -39,7 +39,7 @@ registerOperatorRoute({
  * Orders table route
  */
 registerOperatorRoute({
-  group: "main",
+  group: "navigation",
   priority: 10,
   LayoutComponent: ContentViewExtraWideLayout,
   MainComponent: Orders,

--- a/imports/plugins/core/payments/client/index.js
+++ b/imports/plugins/core/payments/client/index.js
@@ -5,9 +5,8 @@ import { registerOperatorRoute } from "/imports/client/ui";
 import PaymentSettings from "./PaymentSettings.js";
 
 registerOperatorRoute({
-  isNavigationLink: true,
-  isSetting: true,
-  mainComponent: PaymentSettings,
+  group: "settings",
+  MainComponent: PaymentSettings,
   priority: 20,
   path: "/payment",
   // eslint-disable-next-line react/display-name

--- a/imports/plugins/core/shipping/client/index.js
+++ b/imports/plugins/core/shipping/client/index.js
@@ -6,9 +6,8 @@ import { registerOperatorRoute } from "/imports/client/ui";
 import Shipping from "./components/Shipping";
 
 registerOperatorRoute({
-  isNavigationLink: true,
-  isSetting: true,
-  mainComponent: Shipping,
+  group: "settings",
+  MainComponent: Shipping,
   priority: 40,
   path: "/shipping",
   // eslint-disable-next-line react/display-name

--- a/imports/plugins/core/tags/client/index.js
+++ b/imports/plugins/core/tags/client/index.js
@@ -9,25 +9,20 @@ import TagFormPage from "./pages/TagFormPageWithData";
 import TagSettingsPage from "./pages/TagSettingsPageWithData";
 
 registerOperatorRoute({
-  isNavigationLink: false,
-  isSetting: false,
   path: "/tags/create",
-  mainComponent: TagFormPage
+  MainComponent: TagFormPage
 });
 
 registerOperatorRoute({
-  isNavigationLink: false,
-  isSetting: false,
   path: "/tags/edit/:tagId",
-  mainComponent: TagFormPage
+  MainComponent: TagFormPage
 });
 
 registerOperatorRoute({
-  isNavigationLink: true,
-  isSetting: false,
+  group: "main",
   path: "/tags",
   priority: 30,
-  mainComponent: TagSettingsPage,
+  MainComponent: TagSettingsPage,
   // eslint-disable-next-line react/display-name, react/no-multi-comp
   SidebarIconComponent: (props) => <TagIcon {...props} />,
   sidebarI18nLabel: "admin.tags.tags"

--- a/imports/plugins/core/tags/client/index.js
+++ b/imports/plugins/core/tags/client/index.js
@@ -19,7 +19,7 @@ registerOperatorRoute({
 });
 
 registerOperatorRoute({
-  group: "main",
+  group: "navigation",
   path: "/tags",
   priority: 30,
   MainComponent: TagSettingsPage,

--- a/imports/plugins/core/taxes/client/index.js
+++ b/imports/plugins/core/taxes/client/index.js
@@ -5,9 +5,8 @@ import { registerOperatorRoute } from "/imports/client/ui";
 import TaxSettings from "./components/TaxSettings";
 
 registerOperatorRoute({
-  isNavigationLink: true,
-  isSetting: true,
-  mainComponent: TaxSettings,
+  group: "settings",
+  MainComponent: TaxSettings,
   priority: 30,
   path: "/tax-settings",
   // eslint-disable-next-line react/display-name

--- a/imports/plugins/core/templates/client/index.js
+++ b/imports/plugins/core/templates/client/index.js
@@ -7,10 +7,9 @@ import "./templates/settings.html";
 import "./templates/settings.js";
 
 registerOperatorRoute({
-  isNavigationLink: true,
-  isSetting: true,
+  group: "settings",
   path: "/templates",
-  mainComponent: "templateSettings",
+  MainComponent: "templateSettings",
   // eslint-disable-next-line react/display-name
   SidebarIconComponent: (props) => <FontAwesomeIcon icon={faColumns} {...props} />,
   sidebarI18nLabel: "admin.settings.templateSettingsLabel"

--- a/imports/plugins/included/product-admin/client/index.js
+++ b/imports/plugins/included/product-admin/client/index.js
@@ -17,10 +17,8 @@ import withVariant from "./hocs/withVariant";
 
 // Register routes
 registerOperatorRoute({
-  isNavigationLink: false,
-  isSetting: false,
   path: "/products/:handle/:parentVariantId/:variantId",
-  mainComponent: VariantDetail,
+  MainComponent: VariantDetail,
   hocs: [
     withProduct,
     withVariant
@@ -28,10 +26,8 @@ registerOperatorRoute({
 });
 
 registerOperatorRoute({
-  isNavigationLink: false,
-  isSetting: false,
   path: "/products/:handle/:variantId",
-  mainComponent: VariantDetail,
+  MainComponent: VariantDetail,
   hocs: [
     withProduct,
     withVariant
@@ -39,20 +35,17 @@ registerOperatorRoute({
 });
 
 registerOperatorRoute({
-  isNavigationLink: false,
-  isSetting: false,
   path: "/products/:handle",
-  mainComponent: ProductDetailLayout,
+  MainComponent: ProductDetailLayout,
   hocs: [withProduct]
 });
 
 registerOperatorRoute({
-  isNavigationLink: true,
-  isSetting: false,
+  group: "main",
   priority: 20,
-  layoutComponent: ContentViewExtraWideLayout,
+  LayoutComponent: ContentViewExtraWideLayout,
   path: "/products",
-  mainComponent: ProductsTable,
+  MainComponent: ProductsTable,
   // eslint-disable-next-line react/display-name, react/no-multi-comp
   SidebarIconComponent: (props) => <CubeIcon {...props} />,
   sidebarI18nLabel: "admin.products"

--- a/imports/plugins/included/product-admin/client/index.js
+++ b/imports/plugins/included/product-admin/client/index.js
@@ -41,7 +41,7 @@ registerOperatorRoute({
 });
 
 registerOperatorRoute({
-  group: "main",
+  group: "navigation",
   priority: 20,
   LayoutComponent: ContentViewExtraWideLayout,
   path: "/products",


### PR DESCRIPTION
Resolves #223 
Impact: **major**
Type: **feature**

## Issue

A new layout component is needed to satisfy UI requirements for a secondary sidebar with a detail view.

## Solution

- Create the Primary/Detail component
- Use new layout on Navigation dashboard
- Add helper hooks
- Refactor Dashboard
- Refactor route registration

## Screenshots

Mobile with the "more" button

![image](https://user-images.githubusercontent.com/42217/75739553-007bb080-5cba-11ea-80fb-57d1f19a7070.png)

Opened menu

![image](https://user-images.githubusercontent.com/42217/75739619-391b8a00-5cba-11ea-9efc-7ec794465f8f.png)

## Breaking changes

Non-breaking name changes when registering operator routes:
- Old => New
- `layoutComponent` => `LayoutComponent`
- `mainComponent` => `MainComponent`
- `isNavigationLink: true` => `group: "navigation"`
- `isSetting: true` => `group: "settings"`

Warnings will be logged when using the old properties. They'll automatically be transformed into their new values to retain compatibility.

## Testing
1. Run through the app and ensure the views load and look like they should with their layouts.
1. Pay specific attention to the navigation dashboard
1. Resize the nav dashboard add to see the "More" button appears
1. Click to open the menu

Keep in mind the nav editor drag-n-drop doesn't work in the Chrome mobile simulation. Any layout issues not related to the implementation of the Primary/Detail layout can go into another PR.
