### PR TITLE
Optional adaptation for multi-site scenarios

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,4 @@ PUBLIC_FILES_BASE_URL=http://localhost:3000
 PUBLIC_I18N_BASE_URL=http://localhost:3000
 PUBLIC_STOREFRONT_HOME_URL=http://localhost:4000
 ROOT_URL=http://localhost:4080
+OPTIMIZE_FOR_MULTI_SITES=false

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -60,25 +60,34 @@ export default {
   init() {
     // Listen for the primary shop subscription and set accordingly
     return Tracker.autorun(() => {
-      let shop;
-      if (this.Subscriptions.PrimaryShop.ready()) {
-        // There should only ever be one "primary" shop
-        shop = Shops.findOne({
+      let shops;
+      let primaryShop;
+
+      if (this.Subscriptions.UserShops.ready()) {
+        // Find the user's shops
+        shops = Shops.find({
+          shopType: {
+            $ne: "primary"
+          }
+        });
+
+        // Find the primary shop
+        primaryShop = Shops.findOne({
           shopType: "primary"
         });
 
-        if (shop) {
-          this._primaryShopId.set(shop._id);
+        if (primaryShop) {
+          this._primaryShopId.set(primaryShop._id);
+        }
 
-          // if we don't have an active shopId, try to retrieve it from the userPreferences object
-          // and set the shop from the storedShopId
-          if (!this.shopId) {
-            const currentShop = this.getCurrentShop();
+        // if we don't have an active shopId, try to retrieve it from the userPreferences object
+        // and set the shop from the storedShopId
+        if (!this.shopId) {
+          const currentShop = this.getCurrentShop();
 
-            if (currentShop) {
-              this.shopId = currentShop._id;
-              this.shopName = currentShop.name;
-            }
+          if (currentShop) {
+            this.shopId = currentShop._id;
+            this.shopName = currentShop.name;
           }
         }
       }

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -337,7 +337,7 @@ export default {
     if (activeShopId) return Shops.findOne({ _id: activeShopId });
 
     // If no chosen shop, fall back to primary shop
-    if (!Meteor.settings.public.OPTIMIZE_FOR_MULTI_SITES) {
+    if (!Meteor.settings.public.optimizeForMultiSite) {
       return Shops.findOne({ shopType: "primary" });
     }
   },

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -328,7 +328,9 @@ export default {
     if (activeShopId) return Shops.findOne({ _id: activeShopId });
 
     // If no chosen shop, fall back to primary shop
-    return Shops.findOne({ shopType: "primary" });
+    if (!Meteor.settings.public.OPTIMIZE_FOR_MULTI_SITES) {
+      return Shops.findOne({ shopType: "primary" });
+    }
   },
 
   /**

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -63,7 +63,7 @@ export default {
       let shops;
       let primaryShop;
 
-      if (this.Subscriptions.UserShops.ready()) {
+      if (this.Subscriptions.UserShop.ready()) {
         // Find the user's shops
         shops = Shops.find({
           shopType: {

--- a/client/modules/core/subscriptions.js
+++ b/client/modules/core/subscriptions.js
@@ -14,3 +14,4 @@ Subscriptions.BrandAssets = Subscriptions.Manager.subscribe("BrandAssets");
 Subscriptions.Groups = Subscriptions.Manager.subscribe("Groups");
 Subscriptions.MyAccount = Subscriptions.Manager.subscribe("MyAccount");
 Subscriptions.PrimaryShop = Subscriptions.Manager.subscribe("PrimaryShop");
+Subscriptions.UserShops = Subscriptions.Manager.subscribe("UserShops");

--- a/client/modules/core/subscriptions.js
+++ b/client/modules/core/subscriptions.js
@@ -14,4 +14,4 @@ Subscriptions.BrandAssets = Subscriptions.Manager.subscribe("BrandAssets");
 Subscriptions.Groups = Subscriptions.Manager.subscribe("Groups");
 Subscriptions.MyAccount = Subscriptions.Manager.subscribe("MyAccount");
 Subscriptions.PrimaryShop = Subscriptions.Manager.subscribe("PrimaryShop");
-Subscriptions.UserShops = Subscriptions.Manager.subscribe("UserShops");
+Subscriptions.UserShop = Subscriptions.Manager.subscribe("UserShop");

--- a/imports/plugins/core/core/server/config.js
+++ b/imports/plugins/core/core/server/config.js
@@ -1,6 +1,6 @@
 import envalid from "envalid";
 
-const { num, str } = envalid;
+const { bool, num, str } = envalid;
 
 export default envalid.cleanEnv(process.env, {
   OAUTH2_ADMIN_URL: str({
@@ -49,5 +49,9 @@ export default envalid.cleanEnv(process.env, {
   ROOT_URL: str({
     desc: "The canonical root URL for the Reaction Admin server",
     example: "http://localhost:4080"
+  }),
+  OPTIMIZE_FOR_MULTI_SITES: bool({
+    default: false,
+    desc: "Set this to true to prevent reaction-admin from falling back onto the primary shop if none is found"
   })
 });

--- a/imports/plugins/core/core/server/publications/collections/shops.js
+++ b/imports/plugins/core/core/server/publications/collections/shops.js
@@ -1,5 +1,5 @@
 import { Meteor } from "meteor/meteor";
-import { Accounts, Groups, Shops } from "/lib/collections";
+import { Shops } from "/lib/collections";
 
 Meteor.publish("PrimaryShop", () => Shops.find({
   shopType: "primary"
@@ -12,18 +12,10 @@ Meteor.publish("UserShops", () => {
     shopType: "primary"
   });
 
-  const userProfile = Accounts.findOne({ userId: Meteor.userId() });
-  const groupIds = userProfile.groups;
+  const { profile } = Meteor.user();
+  const shopId = profile.preferences && profile.preferences.reaction && profile.preferences.reaction.activeShopId;
 
-  const groups = Groups.find({ _id: { $in: groupIds }});
+  const shopIds = [primaryShop._id, shopId];
 
-  const shopIds = groups.map((group) => {
-    if (group.slug === "owner" && group.shopId !== null) {
-      return group.shopId;
-    }
-  });
-
-  shopIds.push(primaryShop._id);
-  
   return Shops.find({ _id: { $in: shopIds }});
 });

--- a/imports/plugins/core/core/server/publications/collections/shops.js
+++ b/imports/plugins/core/core/server/publications/collections/shops.js
@@ -7,18 +7,12 @@ Meteor.publish("PrimaryShop", () => Shops.find({
   limit: 1
 }));
 
-Meteor.publish("UserShops", () => {
-  const primaryShop = Shops.findOne({
-    shopType: "primary"
-  });
-
+Meteor.publish("UserShop", () => {
   const { profile } = Meteor.users.findOne(Meteor.userId(), { fields: { profile: 1 } });
   const shopId = profile &&
     profile.preferences &&
     profile.preferences.reaction &&
     profile.preferences.reaction.activeShopId;
 
-  const shopIds = [primaryShop._id, shopId];
-
-  return Shops.find({ _id: { $in: shopIds }});
+  return Shops.find({ _id: shopId });
 });

--- a/imports/plugins/core/core/server/publications/collections/shops.js
+++ b/imports/plugins/core/core/server/publications/collections/shops.js
@@ -1,8 +1,29 @@
 import { Meteor } from "meteor/meteor";
-import { Shops } from "/lib/collections";
+import { Accounts, Groups, Shops } from "/lib/collections";
 
 Meteor.publish("PrimaryShop", () => Shops.find({
   shopType: "primary"
 }, {
   limit: 1
 }));
+
+Meteor.publish("UserShops", () => {
+  const primaryShop = Shops.findOne({
+    shopType: "primary"
+  });
+
+  const userProfile = Accounts.findOne({ userId: Meteor.userId() });
+  const groupIds = userProfile.groups;
+
+  const groups = Groups.find({ _id: { $in: groupIds }});
+
+  const shopIds = groups.map((group) => {
+    if (group.slug === "owner" && group.shopId !== null) {
+      return group.shopId;
+    }
+  });
+
+  shopIds.push(primaryShop._id);
+  
+  return Shops.find({ _id: { $in: shopIds }});
+});

--- a/imports/plugins/core/core/server/publications/collections/shops.js
+++ b/imports/plugins/core/core/server/publications/collections/shops.js
@@ -12,8 +12,11 @@ Meteor.publish("UserShops", () => {
     shopType: "primary"
   });
 
-  const { profile } = Meteor.user();
-  const shopId = profile.preferences && profile.preferences.reaction && profile.preferences.reaction.activeShopId;
+  const { profile } = Meteor.users.findOne(Meteor.userId(), { fields: { profile: 1 } });
+  const shopId = profile &&
+    profile.preferences &&
+    profile.preferences.reaction &&
+    profile.preferences.reaction.activeShopId;
 
   const shopIds = [primaryShop._id, shopId];
 

--- a/imports/plugins/core/core/server/startup/index.js
+++ b/imports/plugins/core/core/server/startup/index.js
@@ -17,7 +17,8 @@ const {
   PUBLIC_I18N_BASE_URL,
   PUBLIC_STOREFRONT_HOME_URL,
   REACTION_METEOR_APP_COMMAND_START_TIME,
-  ROOT_URL
+  ROOT_URL,
+  OPTIMIZE_FOR_MULTI_SITES
 } = config;
 
 /**
@@ -69,7 +70,8 @@ export default function startup() {
     oidcUrl: OAUTH2_PUBLIC_URL,
     passwordChangeUrl: OAUTH2_IDP_PUBLIC_CHANGE_PASSWORD_URL,
     rootUrl: ROOT_URL,
-    storefrontHomeUrl: PUBLIC_STOREFRONT_HOME_URL
+    storefrontHomeUrl: PUBLIC_STOREFRONT_HOME_URL,
+    optimizeForMultiSite: OPTIMIZE_FOR_MULTI_SITES
   });
 
   // Main purpose of this right now is to wait to start Meteor app tests


### PR DESCRIPTION
Resolves #234
Impact: **major**
Type: **feature**

## Issue
While the Reaction API supports multi-sites (and with some custom work, multi-vendor marketplaces), `reaction-admin` always falls back to the primary shop in `Reaction.getCurrentShop()`, making it incompatible with such setups.

## Solution
Introduce an environment variable to optimize for multi-site scenarios. When set to true, `reaction-admin` will not fall back to the primary shop and will instead enforce whatever `activeShopId` the user has in their profile.

With this solution, there will be no changes to the experience for single-vendor/single-site setups. However, it will enable developers to offer marketplace/multi-sites plugins and have the core of their features supported in a clean manner out of the box.

## Breaking changes
None.

## Testing
1. Don't set `OPTIMIZE_FOR_MULTI_SITES` yet
2. Log in as the primary shop owner, see that everything is working as it should
3. Create a secondary shop with a second user (for example using [out:grow's marketplace plugin](https://github.com/outgrow/reaction-marketplace) with [its UI plugin](https://github.com/outgrow/reaction-marketplace-ui), both in beta)
4. Log in as this second user, see that the primary shop is shown where it should have been the user's secondary shop
5. Set `OPTIMIZE_FOR_MULTI_SITES=true` in `.env`
6. Create a secondary shop
7. Log in as the secondary shop owner
8. See that the secondary shop is shown instead of the primary one