### PR TITLE
fix: correctly set and render prices for variants and options in product

### DIFF
--- a/imports/plugins/included/product-admin/client/blocks/VariantPricesForm.js
+++ b/imports/plugins/included/product-admin/client/blocks/VariantPricesForm.js
@@ -25,11 +25,12 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const formSchema = new SimpleSchema({
-  price: {
+  "price": {
     type: Number,
     optional: true
   },
-  compareAtPrice: {
+  "compareAtPrice": Object,
+  "compareAtPrice.amount": {
     type: Number,
     optional: true
   }
@@ -73,7 +74,7 @@ const VariantPricesForm = React.forwardRef((props, ref) => {
     validator(formData) {
       return validator(formSchema.clean(formData));
     },
-    value: currentVariant
+    value: (currentVariant && currentVariant.pricing) || {}
   });
 
   const isSaveDisabled = !product || !isDirty || isSubmitting;
@@ -82,58 +83,64 @@ const VariantPricesForm = React.forwardRef((props, ref) => {
     <Card className={classes.card} ref={ref}>
       <CardHeader title={i18next.t("productVariant.prices")} />
       <CardContent>
-        <form
-          onSubmit={(event) => {
-            event.preventDefault();
-            submitForm();
-          }}
-        >
-          <Grid container spacing={1}>
-            <Grid item sm={6}>
-              <TextField
-                type="numeric"
-                className={classes.textField}
-                error={hasErrors(["price"])}
-                fullWidth
-                helperText={getFirstErrorMessage(["price"]) || i18next.t("admin.helpText.price")}
-                label={i18next.t("productVariant.price")}
-                placeholder="0.00"
-                {...getInputProps("price", muiOptions)}
-              />
+        { currentVariant && currentVariant.options ?
+          <span>
+            {i18next.t("productVariant.noPriceTracking")}
+          </span>
+          :
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+              submitForm();
+            }}
+          >
+            <Grid container spacing={1}>
+              <Grid item sm={6}>
+                <TextField
+                  type="numeric"
+                  className={classes.textField}
+                  error={hasErrors(["price"])}
+                  fullWidth
+                  helperText={getFirstErrorMessage(["price"]) || i18next.t("admin.helpText.price")}
+                  label={i18next.t("productVariant.price")}
+                  placeholder="0.00"
+                  {...getInputProps("price", muiOptions)}
+                />
+              </Grid>
+              <Grid item sm={6}>
+                <TextField
+                  type="numeric"
+                  className={classes.textField}
+                  error={hasErrors(["compareAtPrice.amount"])}
+                  fullWidth
+                  helperText={getFirstErrorMessage(["compareAtPrice.amount"]) || i18next.t("admin.helpText.compareAtPrice")}
+                  label={i18next.t("productVariant.compareAtPrice")}
+                  placeholder="0.00"
+                  {...getInputProps("compareAtPrice.amount", muiOptions)}
+                />
+              </Grid>
             </Grid>
-            <Grid item sm={6}>
-              <TextField
-                type="numeric"
-                className={classes.textField}
-                error={hasErrors(["compareAtPrice"])}
-                fullWidth
-                helperText={getFirstErrorMessage(["compareAtPrice"]) || i18next.t("admin.helpText.compareAtPrice")}
-                label={i18next.t("productVariant.compareAtPrice")}
-                placeholder="0.00"
-                {...getInputProps("compareAtPrice", muiOptions)}
-              />
-            </Grid>
-          </Grid>
 
-          <Box display="flex" justifyContent="flex-end" alignItems="center">
-            {!isSaveDisabled &&
+            <Box display="flex" justifyContent="flex-end" alignItems="center">
+              {!isSaveDisabled &&
               <Box paddingRight={2}>
                 <Typography>
                   {i18next.t("productVariant.pricePublishWarning")}
                 </Typography>
               </Box>
-            }
-            <Button
-              color="primary"
-              disabled={isSaveDisabled}
-              isWaiting={isSubmitting}
-              type="submit"
-              variant="contained"
-            >
-              {i18next.t("app.saveChanges")}
-            </Button>
-          </Box>
-        </form>
+              }
+              <Button
+                color="primary"
+                disabled={isSaveDisabled}
+                isWaiting={isSubmitting}
+                type="submit"
+                variant="contained"
+              >
+                {i18next.t("app.saveChanges")}
+              </Button>
+            </Box>
+          </form>
+        }
       </CardContent>
     </Card>
   );

--- a/imports/plugins/included/product-admin/client/blocks/VariantPricesForm.js
+++ b/imports/plugins/included/product-admin/client/blocks/VariantPricesForm.js
@@ -83,7 +83,8 @@ const VariantPricesForm = React.forwardRef((props, ref) => {
     <Card className={classes.card} ref={ref}>
       <CardHeader title={i18next.t("productVariant.prices")} />
       <CardContent>
-        { currentVariant && currentVariant.options ?
+        { currentVariant && Array.isArray(currentVariant.options) &&
+          (currentVariant.options.length > 0) ?
           <span>
             {i18next.t("productVariant.noPriceTracking")}
           </span>

--- a/imports/plugins/included/product-admin/client/graphql/fragments/productVariant.js
+++ b/imports/plugins/included/product-admin/client/graphql/fragments/productVariant.js
@@ -17,6 +17,12 @@ export default gql`
     minOrderQuantity
     optionTitle
     originCountry
+    pricing {
+      compareAtPrice {
+        amount
+      }
+      price
+    }
     shop {
       _id
     }

--- a/imports/plugins/included/product-admin/client/graphql/mutations/updateProductVariantPrices.js
+++ b/imports/plugins/included/product-admin/client/graphql/mutations/updateProductVariantPrices.js
@@ -5,8 +5,12 @@ export default gql`
     updateProductVariantPrices(input: $input) {
       variant {
         _id
-        price
-        compareAtPrice
+        pricing {
+          compareAtPrice {
+            amount
+          }
+          price
+        }
       }
     }
   }

--- a/imports/plugins/included/product-admin/client/hooks/useProduct.js
+++ b/imports/plugins/included/product-admin/client/hooks/useProduct.js
@@ -295,7 +295,7 @@ function useProduct(args = {}) {
             shopId: shopIdLocal,
             prices: {
               price,
-              compareAtPrice
+              compareAtPrice: compareAtPrice.amount
             },
             variantId: variantIdLocal
           }


### PR DESCRIPTION
Impact: **minor**
Type: **bugfix**

## Issue
Not able to set prices on variants nor options

## Solution
There was an underlying with the way prices were stored for variants and options. The issue has been resolved in the API and this PR makes adjustments necessary to use the new `pricing` field.

## Breaking changes
None

## Testing
1. Create a product with a least one variant, no options.
2. Verify the price and compare at price can be set on the variant and saves correctly
3. Add an option to the existing variant
4. Set price and compare at price and verify it saves correctly.
