### PR TITLE
fix: use network-only fetchPolicy for tag table

### DIFF
--- a/imports/plugins/core/tags/client/components/TagDataTable.js
+++ b/imports/plugins/core/tags/client/components/TagDataTable.js
@@ -464,10 +464,9 @@ class TagDataTable extends Component {
       selectWidth: 64
     };
 
-
     // All available props: https://github.com/tannerlinsley/react-table#props
     return (
-      <Query query={query} variables={variables}>
+      <Query query={query} variables={variables} fetchPolicy="network-only">
         {({ data, error, fetchMore, refetch }) => {
           if (error || !data) {
             if (error) Logger.error(error);


### PR DESCRIPTION
Signed-off-by: Loan Laux <loan@outgrow.io>

Resolves #252 
Impact: **major**
Type: **bugfix**

## Issue
Newly created tags don't show up in the table on the Tags page because of the cache policy. Users need to refresh the page to see their new tags appear, which can be misleading and frustrating.

## Solution
Use `fetchPolicy="network-only" for the `getTags` query.

## Breaking changes
None.

## Testing
1. Create a tag
2. Click "Tags" in the sidebar
3. Notice that your tag now shows up without the need to refresh the page manually