### PR TITLE
chore: release v3.0.0-beta.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,29 @@
+# v3.0.0-beta.8
+
+### Features
+
+- feat: Added GraphQL-powered accounts page ([#276](https://github.com/reactioncommerce/reaction-admin/pull/276))
+
+### Fixes
+
+- fix: Set empty tax fields to null ([#258](https://github.com/reactioncommerce/reaction-admin/pull/258))
+
+## Contributors
+
+Thanks to @loan-laux and @derBretti for contributing to this release! 🎉
+
 # v3.0.0-beta.7
 
 This is the seventh beta release of the Reaction Admin project that is designed to work with our new Reaction API.
 
 ### Refactors
 
-refactor: de-meteorize discount codes view ([#255](http://github.com/reactioncommerce/reaction-admin/pull/255))
+- refactor: de-meteorize discount codes view ([#255](http://github.com/reactioncommerce/reaction-admin/pull/255))
 
 ### Fixes
 
-fix: navigation tree not showing up ([#278](http://github.com/reactioncommerce/reaction-admin/pull/278))
-fix: use network-only fetchPolicy for tag table ([#254](http://github.com/reactioncommerce/reaction-admin/pull/254))
+- fix: navigation tree not showing up ([#278](http://github.com/reactioncommerce/reaction-admin/pull/278))
+- fix: use network-only fetchPolicy for tag table ([#254](http://github.com/reactioncommerce/reaction-admin/pull/254))
 
 ## Contributors
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ networks:
 
 services:
   reaction-admin:
-    image: reactioncommerce/admin:3.0.0-beta.7
+    image: reactioncommerce/admin:3.0.0-beta.8
     env_file:
       - ./.env
     networks:

--- a/imports/plugins/included/taxes-rates/client/components/CustomTaxRateForm.js
+++ b/imports/plugins/included/taxes-rates/client/components/CustomTaxRateForm.js
@@ -57,7 +57,7 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
-const sourcingOptions = ["destination","origin"];
+const sourcingOptions = ["destination", "origin"];
 
 const formSchema = new SimpleSchema({
   country: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reaction-admin",
-  "version": "3.0.0-beta.7",
+  "version": "3.0.0-beta.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reaction-admin",
   "description": "Reaction is a modern reactive, real-time event driven ecommerce platform.",
-  "version": "3.0.0-beta.7",
+  "version": "3.0.0-beta.8",
   "main": "main.js",
   "directories": {
     "test": "tests"


### PR DESCRIPTION
# v3.0.0-beta.8

### Features

- feat: Added GraphQL-powered accounts page ([#276](https://github.com/reactioncommerce/reaction-admin/pull/276))

### Fixes

- fix: Set empty tax fields to null ([#258](https://github.com/reactioncommerce/reaction-admin/pull/258))

## Contributors

Thanks to @loan-laux and @derBretti for contributing to this release! 🎉