### PR TITLE
fix: Update defaultParcelSize only when it exists

### DIFF
--- a/imports/plugins/core/i18n/client/components/LocalizationSettingsForm.js
+++ b/imports/plugins/core/i18n/client/components/LocalizationSettingsForm.js
@@ -96,7 +96,7 @@ export default function ShopSettings() {
       cleanedUserInput.currency = code;
 
       // Only update default parcel size when UOL/UOM are changed by the user
-      if (userInput.baseUOL !== shop.baseUOL || userInput.baseUOM !== shop.baseUOM) {
+      if (shop.defaultParcelSize && (userInput.baseUOL !== shop.baseUOL || userInput.baseUOM !== shop.baseUOM)) {
         const parcelSize = {
           weight: convertWeight(shop.baseUOM, userInput.baseUOM, shop.defaultParcelSize.weight),
           height: convertLength(shop.baseUOL, userInput.baseUOL, shop.defaultParcelSize.height),


### PR DESCRIPTION
Signed-off-by: Matias Zuniga <matias.nicolas.zc@gmail.com>

Resolves reactioncommerce/reaction#6257
Impact: **minor**
Type: **bugfix**

## Issue
On a clean install, the Base of Unit Measure or Base Unit of Length cannot be changed unless the Default Parcel Size value is set.
This happens because the code tries to update defaultParcelSize, even if it doesn't exist, throwing `TypeError: Cannot read property 'weight' of null` when trying to calculate the new defaultParcelSize.

## Solution
Check for the existence of defaultParcelSize before trying to calculate an updated value.

## Testing
1. Start a fresh setup with this PR applied.
2. Login as admin user
3. Try and change Base of Unit Measure or Base Unit of Length
4. baseUOM or baseUOL was updated without errors.