### PR TITLE
Fix Reaction.hasPermission method

### DIFF
--- a/imports/plugins/core/core/server/Reaction/core.js
+++ b/imports/plugins/core/core/server/Reaction/core.js
@@ -113,7 +113,7 @@ export default {
         const groupPermissionsForShop = groups.filter((grp) => grp.shopId === shopId).map((grp) => grp.permissions);
         const flattenedGroupPermissionsForShop = _.flattenDeep(groupPermissionsForShop);
         const uniquePermissionsForShop = _.uniq(flattenedGroupPermissionsForShop);
-        accountPermissions[group] = uniquePermissionsForShop;
+        accountPermissions[shopId] = uniquePermissionsForShop;
       });
     }
 


### PR DESCRIPTION
Resolves #issueNumber
Impact: critical
Type: bugfix

## Issue
Currently, when we are iterating through the `uniqueShopIds` we always override the same shopId in the`accountPermissions` object. Finally, we can end up with permission for shop A associated under shop B key in accountPermissions object. Which causes the`hasPermission` returns wrong value. 

## Solution
I've changed the attribute to which we are saving grouped permissions for the shop. The permissions match the shop now. 