### PR TITLE
release v3.0.0-beta.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # v3.0.0-beta.9
 
+### Features
+
+- feat: Enable mock TLS termination on calls to Hydra ([#302](https://github.com/reactioncommerce/reaction-admin/pull/302))
+
 ### Fixes
 
-- fix: Update defaultParcelSize only when it exists([#295](https://github.com/reactioncommerce/reaction-admin/pull/295))
+- fix: Update defaultParcelSize only when it exists ([#295](https://github.com/reactioncommerce/reaction-admin/pull/295))
 - fix: Reaction.hasPermission method shopId ([#298](https://github.com/reactioncommerce/reaction-admin/pull/298))
 
 ## Contributors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# v3.0.0-beta.9
+
+### Fixes
+
+- fix: Update defaultParcelSize only when it exists([#295](https://github.com/reactioncommerce/reaction-admin/pull/295))
+- fix: Reaction.hasPermission method shopId ([#298](https://github.com/reactioncommerce/reaction-admin/pull/298))
+
+## Contributors
+
+Thanks to @manizuca and @mikoscz for contributing to this release! 🎉
+
 # v3.0.0-beta.8
 
 ### Features

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ networks:
 
 services:
   reaction-admin:
-    image: reactioncommerce/admin:3.0.0-beta.8
+    image: reactioncommerce/admin:3.0.0-beta.9
     env_file:
       - ./.env
     networks:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reaction-admin",
-  "version": "3.0.0-beta.8",
+  "version": "3.0.0-beta.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reaction-admin",
   "description": "Reaction is a modern reactive, real-time event driven ecommerce platform.",
-  "version": "3.0.0-beta.8",
+  "version": "3.0.0-beta.9",
   "main": "main.js",
   "directories": {
     "test": "tests"


### PR DESCRIPTION
# v3.0.0-beta.9

### Features

- feat: Enable mock TLS termination on calls to Hydra ([#302](https://github.com/reactioncommerce/reaction-admin/pull/302))

### Fixes

- fix: Update defaultParcelSize only when it exists ([#295](https://github.com/reactioncommerce/reaction-admin/pull/295))
- fix: Reaction.hasPermission method shopId ([#298](https://github.com/reactioncommerce/reaction-admin/pull/298))

## Contributors

Thanks to @manizuca and @mikoscz for contributing to this release! 🎉