### PR TITLE
feat: Enable mock TLS termination on calls to Hydra

### DIFF
--- a/imports/plugins/core/core/server/config.js
+++ b/imports/plugins/core/core/server/config.js
@@ -1,8 +1,12 @@
 import envalid from "envalid";
 
-const { num, str } = envalid;
+const { num, str, bool } = envalid;
 
 export default envalid.cleanEnv(process.env, {
+  MOCK_TLS_TERMINATION: bool({
+    default: false,
+    desc: "The OAuth server requires 'X-Forwarded-Proto' header to be set to 'https'."
+  }),
   OAUTH2_ADMIN_URL: str({
     desc: "An OAuth2 OpenID Connect compliant URL",
     example: "http://hydra.reaction.localhost:4445"

--- a/imports/plugins/core/core/server/startup/oauth.js
+++ b/imports/plugins/core/core/server/startup/oauth.js
@@ -6,10 +6,18 @@ import { Meteor } from "meteor/meteor";
 import config from "../config.js";
 
 const {
+  MOCK_TLS_TERMINATION,
   OAUTH2_ADMIN_URL,
   OAUTH2_CLIENT_ID,
   ROOT_URL
 } = config;
+
+let mockTlsTermination = {};
+if (MOCK_TLS_TERMINATION) {
+  mockTlsTermination = {
+    "X-Forwarded-Proto": "https"
+  };
+}
 
 const makeAbsolute = (relativeUrl, baseUrl = ROOT_URL) => {
   const url = new URL(relativeUrl, baseUrl);
@@ -52,7 +60,7 @@ export async function ensureHydraClient() {
 
   const getClientResponse = await fetch(makeAbsolute(`/clients/${OAUTH2_CLIENT_ID}`, OAUTH2_ADMIN_URL), {
     method: "GET",
-    headers: { "Content-Type": "application/json" }
+    headers: { "Content-Type": "application/json", ...mockTlsTermination }
   });
 
   if (![200, 404].includes(getClientResponse.status)) {
@@ -66,7 +74,7 @@ export async function ensureHydraClient() {
 
     const updateClientResponse = await fetch(makeAbsolute(`clients/${OAUTH2_CLIENT_ID}`, OAUTH2_ADMIN_URL), {
       method: "PUT",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...mockTlsTermination },
       body: JSON.stringify(hydraClient)
     });
 
@@ -81,7 +89,7 @@ export async function ensureHydraClient() {
 
     const response = await fetch(makeAbsolute("/clients", OAUTH2_ADMIN_URL), {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...mockTlsTermination },
       body: JSON.stringify(hydraClient)
     });
 
@@ -110,7 +118,7 @@ export async function ensureHydraClient() {
  */
 export async function expandAuthToken(token) {
   const response = await fetch(makeAbsolute("/oauth2/introspect", OAUTH2_ADMIN_URL), {
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    headers: { "Content-Type": "application/x-www-form-urlencoded", ...mockTlsTermination },
     method: "POST",
     body: `token=${encodeURIComponent(token)}`
   });


### PR DESCRIPTION
Impact: **minor**
Type: **feature**

## Issue
Same change as in https://github.com/reactioncommerce/reaction-identity/pull/35 and https://github.com/reactioncommerce/api-plugin-authentication/pull/6

When Hydra is being a TLS termination, a https header is required otherwise it will reject calls.

## Solution
This PR adds the header when the environment variable it set to request to Hydra. There are 2 functions. One to expand the auth token, the other to verify the OAuth2 client exists (in practice this client check isn't used by us since our client is created in advance).

## Breaking changes
None, default behaviour remains the same.


## Testing
Run against a Hydra instance that not running with `--dangerous-force-http`.
