### PR TITLE
bugfix: make compareAtPrice optional in form schema

### DIFF
--- a/imports/plugins/included/product-admin/client/blocks/VariantPricesForm.js
+++ b/imports/plugins/included/product-admin/client/blocks/VariantPricesForm.js
@@ -29,7 +29,10 @@ const formSchema = new SimpleSchema({
     type: Number,
     optional: true
   },
-  "compareAtPrice": Object,
+  "compareAtPrice": {
+    type: Object,
+    optional: true
+  },
   "compareAtPrice.amount": {
     type: Number,
     optional: true

--- a/imports/plugins/included/product-admin/client/hooks/useProduct.js
+++ b/imports/plugins/included/product-admin/client/hooks/useProduct.js
@@ -295,7 +295,7 @@ function useProduct(args = {}) {
             shopId: shopIdLocal,
             prices: {
               price,
-              compareAtPrice: compareAtPrice.amount
+              compareAtPrice: compareAtPrice?.amount
             },
             variantId: variantIdLocal
           }


### PR DESCRIPTION
Signed-off-by: cristiancc <cristiancamilo.cucunuba@gmail.com>

Resolves #320 
Impact: **minor**
Type: **bugfix**

## Issue
The price can't be add on a variant if compareAtPrice is null

## Solution
make the field `compareAtPrice` optional in the form schema 


## Breaking changes
none

## Testing
1. Create a variant and set the price without touching or adding any value on the field compare at price
2. Save changes and refresh the page
3. See the price of the variant updated
