### PR TITLE
chore: don't use querystring arg for shop type

### DIFF
--- a/imports/plugins/core/dashboard/client/components/OperatorLanding.js
+++ b/imports/plugins/core/dashboard/client/components/OperatorLanding.js
@@ -29,7 +29,7 @@ function OperatorLanding() {
     );
   } else if (!routeParams.shopId && viewer) {
     return (
-      <Redirect to={"/new-shop?primary=true"} />
+      <Redirect to={"/new-shop"} />
     );
   }
 

--- a/imports/plugins/core/dashboard/client/containers/CreateShopForm.js
+++ b/imports/plugins/core/dashboard/client/containers/CreateShopForm.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { registerComponent } from "@reactioncommerce/reaction-components";
 import { useMutation } from "@apollo/react-hooks";
-import { useHistory, useLocation } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 import gql from "graphql-tag";
 import Logger from "/client/modules/logger";
 import CreateShopForm from "../components/CreateShopForm.js";
@@ -15,14 +15,12 @@ const createShopMutation = gql`
     }
   }
 `;
-
 /**
  * CreateShopForm
  * @returns {Node} React component
  */
 export default function CreateShopFormContainer() {
   const [createShop] = useMutation(createShopMutation, { ignoreResults: true });
-  const { search } = useLocation();
   const history = useHistory();
 
   return (
@@ -30,10 +28,7 @@ export default function CreateShopFormContainer() {
       onSubmit={async (input) => {
         const { data } = await createShop({
           variables: {
-            input: {
-              ...input,
-              type: search.includes("primary") ? "primary" : "merchant"
-            }
+            input
           },
           onError(error) {
             Logger.error(error);


### PR DESCRIPTION
Signed-off-by: Loan Laux <loan@outgrow.io>

Impact: **minor**
Type: **refactor|chore**

## Issue
In one of my previous pull requests, I introduced a separate `/new-shop` page for users to create new shops. This page would get the desired shop type (then passed as a `createShop` mutation parameter) from the querystring. To get the current user to create a primary shop, you would redirect them to `/new-shop?primary=true`, or you'd omit the querystring altogether for a secondary shop.

Since the `createShop` mutation already creates a `primary` shop if none exists, or a `merchant` shop if a `primary` was already created, there is no reason for us to explicitly pass the desired shop type when calling `createShop`. We can simply call `createShop` without a shop type, which will result in the same experience to end-users, with less confusion for developers.

## Solution
Remove the use of the querystring parameter to set the shop type. Don't pass the shop type when calling `createShop`, letting the mutation figure out on its own whether to create a `primary` shop or a `merchant` shop.

## Breaking changes
None.


## Testing
1. Create a shop on a fresh new install. The created shop should be of type `primary` in the `Shops` MongoDB collection.
2. With this primary shop created, create a second shop. This new shop should be of type `merchant` in the `Shops` MongoDB collection.