### PR TITLE
fix: hide sidebar on new-shop page

### DIFF
--- a/imports/client/ui/hooks/useCurrentShopId.js
+++ b/imports/client/ui/hooks/useCurrentShopId.js
@@ -23,5 +23,9 @@ export default function useCurrentShopId() {
 
   const { shopId } = route.params;
 
+  if (shopId === "new-shop") {
+    return [];
+  }
+
   return [shopId];
 }


### PR DESCRIPTION
Signed-off-by: Loan Laux <loan@outgrow.io>

Impact: **major**
Type: **bugfix**

## Issue
The sidebar is shown even when on the `/new-shop` page, which shouldn't be the case. When clicking on a sidebar link from the `/new-shop` page, the basic routing thingy that I implemented will think that the current shop ID is `new-shop`, resulting in users landing on pages like `/new-shop/products`, which obviously isn't desired.

## Solution
Make `useCurrentShopId` return no shop ID when the `new-shop` page is shown. This way, the sidebar will be hidden, and any other part using `useCurrentShopId` will know that there's currently no shop ID selected.

## Breaking changes
None.


## Testing
1. Open the `/new-shop` page.
2. Check that the sidebar links are hidden.
3. Select a shop.
4. Check that the sidebar links are shown.
