### PR TITLE
fix: shop selector blank on page load

### DIFF
--- a/imports/client/ui/components/ShopSelectorWithData/ShopSelectorWithData.js
+++ b/imports/client/ui/components/ShopSelectorWithData/ShopSelectorWithData.js
@@ -11,6 +11,7 @@ import Select from "@material-ui/core/Select";
 import Typography from "@material-ui/core/Typography";
 import withStyles from "@material-ui/core/styles/withStyles";
 import { withComponents } from "@reactioncommerce/components-context";
+import useCurrentShopId from "/imports/client/ui/hooks/useCurrentShopId";
 
 const defaultLogo = "/resources/reaction-logo-circular.svg";
 
@@ -65,8 +66,9 @@ const ShopSelectorInput = withStyles(() => ({
  * @param {Object} props Component props
  * @returns {Node} React component
  */
-function ShopSelectorWithData({ className, classes, shouldShowShopName, shopId, linkTo, size, viewer }) {
+function ShopSelectorWithData({ className, classes, shouldShowShopName, linkTo, size, viewer }) {
   const location = useLocation();
+  const [currentShopId] = useCurrentShopId();
 
   let adminUIShops = [];
 
@@ -98,7 +100,7 @@ function ShopSelectorWithData({ className, classes, shouldShowShopName, shopId, 
   }
 
   return (
-    <Select classes={{ selectMenu: classes.selectMenu, icon: classes.selectArrow }} value={shopId} input={<ShopSelectorInput />}>
+    <Select classes={{ selectMenu: classes.selectMenu, icon: classes.selectArrow }} value={currentShopId || "new-shop"} input={<ShopSelectorInput />}>
       {adminUIShops.map((shop) => {
         const customLogoFromUpload = shop.brandAssets && shop.brandAssets.navbarBrandImage && shop.brandAssets.navbarBrandImage.large;
         const customLogoFromUrlInput = shop.shopLogoUrls && shop.shopLogoUrls.primaryShopLogoUrl;

--- a/imports/client/ui/components/Sidebar/Sidebar.js
+++ b/imports/client/ui/components/Sidebar/Sidebar.js
@@ -168,7 +168,6 @@ function Sidebar(props) {
           <ShopSelectorWithData
             className={classes.shopLogo}
             shouldShowShopName
-            shopId={currentShopId}
             size={32}
             viewer={viewer}
           />


### PR DESCRIPTION
Signed-off-by: Loan Laux <loan@outgrow.io>

Impact: **minor**
Type: **bugfix**

## Issue
The shop selector shows no selected shop on the first page load, even if one is in fact selected or the user is viewing the `/new-shop` page.

## Solution
Use `useCurrentShopId` hook inside the `ShopSelectorWithData` component instead of passing the `shopId` as a prop.

## Breaking changes
None.

## Testing
1. Load any shop-specific page, check that the shop name is showing up as selected in the top-left corner.
2. Load the `/new-shop` page, check that "New Shop" is showing up as selected in the top-left corner.