### PR TITLE
Add shouldShowSidebarLink to registerOperatorRoute

### DIFF
--- a/imports/client/ui/hooks/useCurrentShop.js
+++ b/imports/client/ui/hooks/useCurrentShop.js
@@ -20,6 +20,7 @@ const getShopQuery = gql`
       shopLogoUrls {
         primaryShopLogoUrl
       }
+      shopType
       storefrontUrls {
         storefrontHomeUrl
         storefrontLoginUrl

--- a/imports/client/ui/hooks/useCurrentShop.js
+++ b/imports/client/ui/hooks/useCurrentShop.js
@@ -44,7 +44,7 @@ export default function useCurrentShop() {
   });
 
   // Wait until we're sure we have a shop ID to call the query
-  if (shopId && !called) {
+  if ((shopId && !called) || (shopId && !loading && data?.shop?._id !== shopId)) {
     getShop({
       variables: { id: shopId }
     });

--- a/imports/client/ui/hooks/useOperatorRoutes.js
+++ b/imports/client/ui/hooks/useOperatorRoutes.js
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { operatorRoutes } from "../index";
+import useCurrentShop from "/imports/client/ui/hooks/useCurrentShop.js";
 
 export const defaultRouteSort = (routeA, routeB) => (
   (routeA.priority || Number.MAX_SAFE_INTEGER) - (routeB.priority || Number.MAX_SAFE_INTEGER)
@@ -21,6 +22,8 @@ export default function useOperatorRoutes(options = {}) {
     sort = defaultRouteSort
   } = options;
 
+  const { shop } = useCurrentShop();
+
   const routes = useMemo(() => {
     let filteredRoutes;
     if (Array.isArray(groups)) {
@@ -33,6 +36,16 @@ export default function useOperatorRoutes(options = {}) {
 
     if (sort) {
       filteredRoutes = filteredRoutes.sort(sort);
+    }
+
+    if (shop) {
+      filteredRoutes = filteredRoutes.filter(({ shouldShowSidebarLink }) => {
+        if (shouldShowSidebarLink) {
+          return shouldShowSidebarLink(shop);
+        }
+
+        return true;
+      });
     }
 
     return filteredRoutes;

--- a/imports/client/ui/hooks/useOperatorRoutes.js
+++ b/imports/client/ui/hooks/useOperatorRoutes.js
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
+import useCurrentShop from "/imports/client/ui/hooks/useCurrentShop";
 import { operatorRoutes } from "../index";
-import useCurrentShop from "/imports/client/ui/hooks/useCurrentShop.js";
 
 export const defaultRouteSort = (routeA, routeB) => (
   (routeA.priority || Number.MAX_SAFE_INTEGER) - (routeB.priority || Number.MAX_SAFE_INTEGER)
@@ -22,7 +22,10 @@ export default function useOperatorRoutes(options = {}) {
     sort = defaultRouteSort
   } = options;
 
-  const { shop } = useCurrentShop();
+  const { shop, shopId } = useCurrentShop();
+  console.log(shopId);
+  console.log(shop);
+
 
   const routes = useMemo(() => {
     let filteredRoutes;
@@ -49,7 +52,7 @@ export default function useOperatorRoutes(options = {}) {
     }
 
     return filteredRoutes;
-  }, [filter, groups, sort]);
+  }, [filter, groups, sort, shop]);
 
   return routes;
 }

--- a/imports/client/ui/hooks/useOperatorRoutes.js
+++ b/imports/client/ui/hooks/useOperatorRoutes.js
@@ -22,10 +22,7 @@ export default function useOperatorRoutes(options = {}) {
     sort = defaultRouteSort
   } = options;
 
-  const { shop, shopId } = useCurrentShop();
-  console.log(shopId);
-  console.log(shop);
-
+  const { shop } = useCurrentShop();
 
   const routes = useMemo(() => {
     let filteredRoutes;

--- a/imports/client/ui/index.js
+++ b/imports/client/ui/index.js
@@ -33,7 +33,8 @@ export function registerOperatorRoute(route) {
     layoutComponent,
     mainComponent,
     MainComponent,
-    path
+    path,
+    shouldShowSidebarLink
   } = route;
   const additionalProps = {};
 
@@ -75,7 +76,8 @@ export function registerOperatorRoute(route) {
     operatorRoutes.push({
       ...route,
       ...additionalProps,
-      MainComponent: component
+      MainComponent: component,
+      shouldShowSidebarLink
     });
   }
 
@@ -85,7 +87,8 @@ export function registerOperatorRoute(route) {
       ...additionalProps,
       path: `/:shopId${path}`,
       href: href ? `/:shopId${href}` : null,
-      MainComponent: component
+      MainComponent: component,
+      shouldShowSidebarLink
     });
   }
 }


### PR DESCRIPTION
Impact: **minor**
Type: **feature**

## Issue
There's currently no clean way for developers to programmatically decide whether to show their `reaction-admin` plugin's link in the sidebar depending on the current shop.

## Solution
Introduce the `shouldShowSidebarLink` option for `registerOperatorRoute`. `shouldShowSidebarLink` takes a function that should expect the current shop as its only argument and should return true if the sidebar link should be shown, or false if it shouldn't.

Example usage for a link should only be shown when viewing the primary shop:

```

registerOperatorRoute({
  group: "navigation",
  mainComponent: SomePlugin,
  path: "/some-plugin",
  shouldShowSidebarLink: (currentShop) => currentShop.shopType === "primary"
});
```

## Breaking changes
None.

## Testing
1. Register a route using `shouldShowSidebarLink`.
2. Make sure the route link show up (or doesn't) as you expect it to in the sidebar.
