### PR TITLE
Fix order detail page link

### DIFF
--- a/imports/plugins/core/orders/client/components/OrdersTable.js
+++ b/imports/plugins/core/orders/client/components/OrdersTable.js
@@ -155,8 +155,8 @@ function OrdersTable() {
 
   // Row click callback
   const onRowClick = useCallback(async ({ row }) => {
-    history.push(`/orders/${row.values.referenceId}`);
-  }, [history]);
+    history.push(`/${shopId}/orders/${row.values.referenceId}`);
+  }, [history, shopId]);
 
   const labels = useMemo(() => ({
     "globalFilterPlaceholder": i18next.t("admin.table.filter.globalFilter"),


### PR DESCRIPTION
Signed-off-by: Loan Laux <loan@outgrow.io>

Resolves #336
Impact: **critical**
Type: **bugfix**

## Issue
No idea how this wasn't noticed before, but the order detail links on the `Orders` page have been broken ever since we introduced the shop selector.

## Solution
Include the `shopId` prefix in the order detail page URLs.

## Breaking changes
None.


## Testing
1. Go to the `Orders` page.
2. Click on any order for details.
3. The order detail page should work fine.