### PR TITLE
Fix: Tags not rendering without manual refresh

### DIFF
--- a/imports/plugins/included/product-admin/client/blocks/ProductTagForm.js
+++ b/imports/plugins/included/product-admin/client/blocks/ProductTagForm.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { i18next } from "/client/api";
 import {
   Card,
@@ -31,7 +31,9 @@ function ProductTagForm() {
     handleDeleteProductTag({ tag });
   }, [handleDeleteProductTag]);
 
-  refetchProduct();
+  useEffect(() => {
+    refetchProduct();
+  });
 
   if (product && Array.isArray(product.tags.nodes)) {
     content = product.tags.nodes.map((tag) => (

--- a/imports/plugins/included/product-admin/client/blocks/ProductTagForm.js
+++ b/imports/plugins/included/product-admin/client/blocks/ProductTagForm.js
@@ -31,6 +31,8 @@ function ProductTagForm() {
     handleDeleteProductTag({ tag });
   }, [handleDeleteProductTag]);
 
+  refetchProduct();
+
   if (product && Array.isArray(product.tags.nodes)) {
     content = product.tags.nodes.map((tag) => (
       <Box

--- a/imports/plugins/included/product-admin/client/blocks/ProductTagForm.js
+++ b/imports/plugins/included/product-admin/client/blocks/ProductTagForm.js
@@ -33,6 +33,7 @@ function ProductTagForm() {
 
   useEffect(() => {
     refetchProduct();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   if (product && Array.isArray(product.tags.nodes)) {

--- a/imports/plugins/included/product-admin/client/blocks/ProductTagForm.js
+++ b/imports/plugins/included/product-admin/client/blocks/ProductTagForm.js
@@ -33,7 +33,7 @@ function ProductTagForm() {
 
   useEffect(() => {
     refetchProduct();
-  });
+  }, []);
 
   if (product && Array.isArray(product.tags.nodes)) {
     content = product.tags.nodes.map((tag) => (


### PR DESCRIPTION
Signed-off-by: Jess Wolvington jess.wolvington@gmail.com

Resolves #287 
Impact: **minor**
Type: **bugfix**

## Issue
When adding a tag to products via the multiple items operation, the tag does not show up in the product detail screen until you modify the record or manually refresh the page

To reproduce the issue: 
1. Navigate to the Products tab.
2. Select several products.
2. Choose "Add/Remove Tags" from the `Actions` dropdown.
3. Navigate to the detail page for one of the newly tagged products.
4. Observe the just-added tags do not appear.
5. Refresh page, observe the newly added tag appears.

## Solution
This bug can be fixed with a simple refreshProduct invocation prior to mapping through the tag nodes. Previously the tag nodes had not been refreshed prior to entering the detail page, thus hadn't been fetched at that point. Refetching the product data before mapping the tag nodes will ensure the data is there before the nodes are mapped.

## Breaking changes
None

## Testing
1. Navigate to the Products tab.
2. Select several products.
2. Choose "Add/Remove Tags" from the `Actions` dropdown.
3. Click to enter detail page for one of the newly tagged products.
4. Observe the just-added tags appear without any further action (previously the user would have had to refresh the page manually).
