### PR TITLE
allow empty strings in shopURL

### DIFF
--- a/imports/plugins/core/dashboard/client/components/ShopLogoUrls.js
+++ b/imports/plugins/core/dashboard/client/components/ShopLogoUrls.js
@@ -30,7 +30,7 @@ const shopLogoUrlsSchema = new SimpleSchema({
   "shopLogoUrls": Object,
   "shopLogoUrls.primaryShopLogoUrl": {
     type: String,
-    regEx: SimpleSchema.RegEx.Url,
+    regEx: `${SimpleSchema.RegEx.Url}|(^$)`, // a URL or an empty string
     optional: true
   }
 });
@@ -88,11 +88,11 @@ export default function ShopLogoUrls() {
   } = useReactoForm({
     async onSubmit(formData) {
       setIsSubmitting(true);
-      await handleUpdateUrls(shopLogoUrlsSchema.clean(formData));
+      await handleUpdateUrls(shopLogoUrlsSchema.clean(formData, { removeEmptyStrings: false }));
       setIsSubmitting(false);
     },
     validator(formData) {
-      return validator(shopLogoUrlsSchema.clean(formData));
+      return validator(shopLogoUrlsSchema.clean(formData, { removeEmptyStrings: false }));
     },
     value: shop
   });


### PR DESCRIPTION
Resolves #291 
Impact: **minor**
Type: **bugfix**

## Issue
The SimpleSchema was cleaning the object of empty string before saving it. Also the RegEx was not allowing empty strings to pass.

## Solution
1. Configured cleaning to not remove empty strings.
2. Modified regex to allow empty string.

## Breaking changes
None expected


## Testing
1. Login as Admin
2. Enter a URL for the store logo and save it. The top left icon should update based on the URL you entered
3. Remove the URL and hit Save, the logo should default back to the Reaction Commerce logo.