### PR TITLE
Fix: Make title in product form required in validation to prevent error in storefront

### DIFF
--- a/imports/plugins/included/product-admin/client/blocks/ProductDetailForm.js
+++ b/imports/plugins/included/product-admin/client/blocks/ProductDetailForm.js
@@ -33,7 +33,7 @@ const useStyles = makeStyles((theme) => ({
 const formSchema = new SimpleSchema({
   title: {
     type: String,
-    optional: true
+    optional: false
   },
   permalink: {
     type: String,


### PR DESCRIPTION
Signed-off-by: jrw421 <jessica.wolvington@gmail.com>

Resolves #304 
Impact: **minor**
Type: **bugfix**

## Issue
Admin can save and publish a product without adding its title. This product, when published, is naturally displayed on the storefront side. When the customer tries to open PDP for that product, the system throws `404 Not Found error (in case of Mac)` and `Sorry! We couldn't find what you're looking for` error (in case of Ubuntu).

## Solution
Make title a required field in the new product form to prevent further issues. Additionally will be adding error handling on the example-storefront to mitigate pre-existing issues.

## Breaking changes
None expected.

## Testing
1. Go to Product -> Create product
2. Create a product but leave the `title` field empty. 
3. Save the product.
4. The form should prevent the user from saving and give the error `Title is required`.
5. Add a title and press `save`.
6. The product should save successfully. 
