### PR TITLE
fix: prevent race condition between i18next causing translation to fail

### DIFF
--- a/client/modules/i18n/startup.js
+++ b/client/modules/i18n/startup.js
@@ -15,6 +15,8 @@ import i18next, { getLabelsFor, getValidationErrorMessages, i18nextDep } from ".
 
 const { i18nBaseUrl } = Meteor.settings.public;
 
+// Keep track of current langage.
+let currentLanguage = null;
 const configuredI18next = i18next
   // https://github.com/i18next/i18next-browser-languageDetector
   // Sets initial language to load based on `lng` query string
@@ -107,9 +109,12 @@ Meteor.startup(() => {
   Tracker.autorun(() => {
     const shopId = Reaction.getPrimaryShopId();
     const shop = shopId && Shops.findOne({ _id: shopId });
-    const shopLanguage = (shop && shop.language) || null;
-
-    initializeI18n(shopLanguage || "en");
+    const shopLanguage = (shop && shop.language) || "en";
+    // Only need to re-initialize if the language was switched
+    if (shopLanguage !== currentLanguage) {
+      currentLanguage = shopLanguage;
+      initializeI18n(shopLanguage);
+    }
   });
 
   //


### PR DESCRIPTION
Resolves #309, #300
Impact: **major**
Type: **bugfix**

## Issue
One of the flow that was causing this problem was:
1. Before getting shop, we load "en" translations.
2. The page is rendered.
3. Now we get the shop, we again try to load the "en" translation in the same object.
4. Before the object is ready React is re-rendering the components and the translations are all failing.
5. The object loads, but the translations are already empty.

Note this is one possible flow, since the stuff is happening is `async` more could be possible.

## Solution
Don't load the translations again until the language is changed.

## Breaking changes
None exptected

## Testing
1. Start the platform.
2. Visit admin, refresh the page a bunch of times. Now every-time the correct translations should load.
