### PR TITLE
Enable admin UI access for invited staff members

### DIFF
--- a/imports/plugins/core/accounts/client/components/InviteShopMemberDialog.js
+++ b/imports/plugins/core/accounts/client/components/InviteShopMemberDialog.js
@@ -92,7 +92,8 @@ function InviteShopMember({ isOpen, onClose, onSuccess, groups, shopId }) {
             email: formData.email,
             groupIds: selectedGroups.map((role) => role.value),
             name: formData.name,
-            shopId
+            shopId,
+            shouldGetAdminUIAccess: true
           }
         }
       });


### PR DESCRIPTION
Signed-off-by: Loan Laux <loan@outgrow.io>

Resolves #330
Impact: **critical**
Type: **bugfix**

## Issue
Invited staff members don't get access to the admin UI for their shop.

## Solution
I can't believe this wasn't noticed earlier, but the `shoudlGetAdminUIAccess: true` parameter was missing from the `inviteShopMember` mutation call.

## Breaking changes
None.

## Testing
1. Invite a staff member as part of the `shop manager` group.
2. Sign up with the invited e-mail.
3. The admin UI should load fine for the shop that e-mail was invited to.
