### PR TITLE
Use pricing instead of price in products query

### DIFF
--- a/imports/plugins/included/product-admin/client/components/ProductsTable.js
+++ b/imports/plugins/included/product-admin/client/components/ProductsTable.js
@@ -103,7 +103,7 @@ function ProductsTable() {
     },
     {
       Header: i18next.t("admin.productTable.header.price"),
-      accessor: "price.range"
+      accessor: "pricing.displayPrice"
     },
     {
       Header: i18next.t("admin.productTable.header.published"),

--- a/imports/plugins/included/product-admin/client/graphql/queries/products.js
+++ b/imports/plugins/included/product-admin/client/graphql/queries/products.js
@@ -13,8 +13,8 @@ export default gql`
             thumbnail
           }
         }
-        price {
-          range
+        pricing {
+          displayPrice
         }
         publishedProductHash
         variants {


### PR DESCRIPTION
Signed-off-by: Loan Laux <loan@outgrow.io>

Resolves #288
Impact: **minor**
Type: **bugfix**

## Issue
The `products` query is fetching prices by querying the `price` field which has been deprecated.

## Solution
Query `pricing` instead of `price`.

## Breaking changes
None.

## Testing
1. Open the `Products` page and make sure there are products in the table.
2. Check the API logs and notice there are no deprecation warnings anymore.
