### PR TITLE
Fix generateSitemap returning Access Denied

### DIFF
--- a/imports/plugins/included/sitemap-generator/client/components/SitemapSettings.js
+++ b/imports/plugins/included/sitemap-generator/client/components/SitemapSettings.js
@@ -89,7 +89,13 @@ export default function SitemapSettings() {
   const { sitemapRefreshPeriod } = data && data.shopSettings;
 
   const onGenerateClick = () => {
-    generateSitemaps();
+    generateSitemaps({
+      variables: {
+        input: {
+          shopId
+        }
+      }
+    });
     Alerts.toast(i18next.t("shopSettings.sitemapRefreshInitiated"), "success");
   };
 


### PR DESCRIPTION
Signed-off-by: Loan Laux <loan@outgrow.io>

Resolves #318
Impact: **critical**
Type: **bugfix**

## Issue
The "Generate Sitemap" button in the Shop settings, which calls the `generateSitemap` mutation, always results in an `Access Denied` error being returned. This is because the `shopId` is not passed when calling the mutation.

## Solution
Pass `shopId` when calling `generateSitemap`.

## Breaking changes
None.

## Testing
1. Go to `Settings > Shop`.
2. Click "Generate Sitemap" and ensure that no error is thrown.
