### PR TITLE
Add LKR currency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,10 @@ workflows:
           requires:
             - install-dependencies
       - docker-build-push:
+          filters:
+            branches:
+              only:
+                - trunk
           context: reaction-publish-docker
           requires:
             - dockerfile-lint

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ networks:
 
 services:
   reaction-admin:
-    image: dileepa/admin:latest
+    image: reactioncommerce/admin:3.0.0-beta.13
     env_file:
       - ./.env
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ networks:
 
 services:
   reaction-admin:
-    image: reactioncommerce/admin:3.0.0-beta.13
+    image: dileepa/admin:latest
     env_file:
       - ./.env
     networks:

--- a/imports/utils/CurrencyDefinitions.js
+++ b/imports/utils/CurrencyDefinitions.js
@@ -169,7 +169,7 @@ export default {
     scale: 0
   },
   CNY: {
-    enabled: false,
+    enabled: true,
     format: "%s%v",
     symbol: "¥"
   },
@@ -232,12 +232,12 @@ export default {
     thousand: "."
   },
   DZD: {
-    enabled: false,
+    enabled: true,
     format: "%v %s",
     symbol: "دج"
   },
   EGP: {
-    enabled: false,
+    enabled: true,
     format: "%s%v",
     symbol: "£",
     decimal: ",",
@@ -259,7 +259,7 @@ export default {
     symbol: "$"
   },
   EUR: {
-    enabled: false,
+    enabled: true,
     format: "%v %s",
     symbol: "€",
     decimal: ",",
@@ -288,7 +288,7 @@ export default {
     symbol: "£"
   },
   GBP: {
-    enabled: false,
+    enabled: true,
     format: "%s%v",
     symbol: "£"
   },
@@ -347,7 +347,7 @@ export default {
     thousand: "."
   },
   ILS: {
-    enabled: false,
+    enabled: true,
     format: "%s%v",
     symbol: "₪"
   },
@@ -417,7 +417,7 @@ export default {
     symbol: "$"
   },
   NGN: {
-    enabled: false,
+    enabled: true,
     format: "%s%v",
     symbol: "₦"
   },
@@ -444,7 +444,7 @@ export default {
     symbol: "﷼"
   },
   RUB: {
-    enabled: false,
+    enabled: true,
     format: "%v %s",
     symbol: "руб.",
     decimal: ",",

--- a/imports/utils/CurrencyDefinitions.js
+++ b/imports/utils/CurrencyDefinitions.js
@@ -169,7 +169,7 @@ export default {
     scale: 0
   },
   CNY: {
-    enabled: true,
+    enabled: false,
     format: "%s%v",
     symbol: "¥"
   },
@@ -232,12 +232,12 @@ export default {
     thousand: "."
   },
   DZD: {
-    enabled: true,
+    enabled: false,
     format: "%v %s",
     symbol: "دج"
   },
   EGP: {
-    enabled: true,
+    enabled: false,
     format: "%s%v",
     symbol: "£",
     decimal: ",",
@@ -259,7 +259,7 @@ export default {
     symbol: "$"
   },
   EUR: {
-    enabled: true,
+    enabled: false,
     format: "%v %s",
     symbol: "€",
     decimal: ",",
@@ -288,7 +288,7 @@ export default {
     symbol: "£"
   },
   GBP: {
-    enabled: true,
+    enabled: false,
     format: "%s%v",
     symbol: "£"
   },
@@ -347,7 +347,7 @@ export default {
     thousand: "."
   },
   ILS: {
-    enabled: true,
+    enabled: false,
     format: "%s%v",
     symbol: "₪"
   },
@@ -378,6 +378,11 @@ export default {
     enabled: false,
     format: "%v %s",
     symbol: "KZT"
+  },
+  LKR: {
+    enabled: true,
+    format: "%s%v",
+    symbol: "Rs. "
   },
   MAD: {
     enabled: false,
@@ -412,7 +417,7 @@ export default {
     symbol: "$"
   },
   NGN: {
-    enabled: true,
+    enabled: false,
     format: "%s%v",
     symbol: "₦"
   },
@@ -439,7 +444,7 @@ export default {
     symbol: "﷼"
   },
   RUB: {
-    enabled: true,
+    enabled: false,
     format: "%v %s",
     symbol: "руб.",
     decimal: ",",

--- a/imports/utils/CurrencyDefinitions.js
+++ b/imports/utils/CurrencyDefinitions.js
@@ -381,8 +381,8 @@ export default {
   },
   LKR: {
     enabled: true,
-    format: "%s%v",
-    symbol: "Rs. "
+    format: "%s %v",
+    symbol: "Rs."
   },
   MAD: {
     enabled: false,

--- a/imports/utils/CurrencyDefinitions.js
+++ b/imports/utils/CurrencyDefinitions.js
@@ -379,6 +379,11 @@ export default {
     format: "%v %s",
     symbol: "KZT"
   },
+  LKR: {
+    enabled: true,
+    format: "%s %v",
+    symbol: "Rs."
+  },
   MAD: {
     enabled: false,
     format: "%v %s",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "immutable": "^3.8.2",
     "jquery-i18next": "1.2.1",
     "libphonenumber-js": "1.4.2",
-    "lodash": "^4.17.13",
+    "lodash": "^4.17.21",
     "match-sorter": "^2.3.0",
     "mdi-material-ui": "^6.2.0",
     "meteor-node-stubs": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "reacto-form": "^1.5.0",
     "recompose": "^0.26.0",
     "shallowequal": "^1.0.2",
-    "simpl-schema": "1.5.0",
+    "simpl-schema": "1.10.2",
     "slugify": "1.3.1",
     "store": "^2.0.12",
     "stripe": "^7.10.0",


### PR DESCRIPTION
Impact: **minor**
Type: **bugfix**

## Issue
No LKR currency definition in `imports -> utils -> CurrencyDefinitions.js` 

## Solution

Add LKR currency definition `
  LKR: {
    enabled: true,
    format: "%s%v",
    symbol: "Rs. "
  },`
 in `imports -> utils -> CurrencyDefinitions.js` 

This is relative to [https://github.com/reactioncommerce/api-utils/pull/79](https://github.com/reactioncommerce/api-utils/pull/79)