### PR TITLE
chore: docker push only trunk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,10 @@ workflows:
           requires:
             - install-dependencies
       - docker-build-push:
+          filters:
+            branches:
+              only:
+                - trunk
           context: reaction-publish-docker
           requires:
             - dockerfile-lint


### PR DESCRIPTION
Resolves #366 
Impact: **minor**
Type: **chore**

Filters branch on which circleci pushes to docker.