### PR TITLE
fix: add LKR currency

### DIFF
--- a/imports/utils/CurrencyDefinitions.js
+++ b/imports/utils/CurrencyDefinitions.js
@@ -379,6 +379,11 @@ export default {
     format: "%v %s",
     symbol: "KZT"
   },
+  LKR: {
+    enabled: true,
+    format: "%s %v",
+    symbol: "Rs."
+  },
   MAD: {
     enabled: false,
     format: "%v %s",


### PR DESCRIPTION
Impact: minor
Type: bugfix

Issue
No LKR currency definition in imports -> utils -> CurrencyDefinitions.js

Solution
Add LKR currency definition LKR: { enabled: true, format: "%s %v", symbol: "Rs." },
in imports -> utils -> CurrencyDefinitions.js

This is relative to [reactioncommerce/api-utils#79](https://github.com/reactioncommerce/api-utils/pull/79)