### PR TITLE
fix: blank screen on production creation

### DIFF
--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -174,7 +174,7 @@ export default {
       permissions = _.uniq(permissions);
 
       // if accountPermissions includes any of permissions, then we return true
-      return accountPermissions[permissionsGroup].some((permission) => permissions.includes(permission));
+      return accountPermissions[permissionsGroup] && accountPermissions[permissionsGroup].some((permission) => permissions.includes(permission));
     }
 
     /**

--- a/imports/plugins/core/core/server/Reaction/core.js
+++ b/imports/plugins/core/core/server/Reaction/core.js
@@ -118,7 +118,7 @@ export default {
     }
 
     // if accountPermissions includes any of checkPermissions, then we return true
-    return accountPermissions[group].some((permission) => checkPermissions.includes(permission));
+    return accountPermissions[group] && accountPermissions[group].some((permission) => checkPermissions.includes(permission));
   },
 
   /**


### PR DESCRIPTION
Signed-off-by: Loan Laux <loan@outgrow.io>

Resolves #376
Impact: **breaking**
Type: **bugfix**

## Issue
In some specific marketplace instances, when creating a new product, `roleCheck` and `hasPermissions` can sometimes cause a blank screen to appear after clicking the "Create product" button. The error message that shows in the browser console is `a[b].some cannot read property 'some' of undefined`.

## Solution
Implement a null guard in `roleCheck` and `hasPermissions`.

## Breaking changes

None.

## Testing

1. Use the `@outgrowio/reaction-marketplace` plugin.
2. Create a primary shop. Then, invite a new merchant using the plugin's API.
3. Sign up with the e-mail used for the invitation. Then, create a shop.
4. Try to create a product. The product should be created without any issue.