### PR TITLE
fix: docker build fails on circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,7 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
+          version: 20.10.6
       - run:
           name: Build and push production Docker image
           command: |


### PR DESCRIPTION
Signed-off-by: Mohan Narayana <mohan.narayana@mailchimp.com>

Impact: **minor**
Type: **bugfix**

## Issue

Docker build fails on Circle CI due to incompatible docker version which is picked by default.

## Solution

Fix the docker version to 20.10.6

