### PR TITLE
fix: use 14 for node image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN printf "\\n[-] Building Meteor application...\\n" \
 ##############################################################################
 # final build stage - create the final production image
 ##############################################################################
-FROM node:12.20.1-slim
+FROM node:14-slim
 
 LABEL maintainer="Reaction Commerce <engineering@reactioncommerce.com>"
 


### PR DESCRIPTION
## Issue

We were using node 12 for building the prod image, but newer version of Meteor requires atleast 14.

## Solution

Upgrade the base image to 14.

## Testing
1. Build the image, using docker build and tag it with test
2. Use the `test` tag in reaction-admin/docker-compose.yml.
3. Run `make` to start the containers in prod mode.
4. Test that admin works.