### PR TITLE
fix: upgrade admin version in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ networks:
 
 services:
   reaction-admin:
-    image: reactioncommerce/admin:3.0.0-beta.24
+    image: reactioncommerce/admin:4.0.0-beta.4
     env_file:
       - ./.env
     networks:


### PR DESCRIPTION
## Issue

The admin's docker-compose.yml wasn't updated as part of the update from semantic-release.

## Solution

Manually updating the version number.

## Breaking changes

None