### PR TITLE
feat: updated CircleCi config to add latest tag to docker image.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,9 +92,10 @@ jobs:
           name: Build and push production Docker image
           command: |
             VERSION=$(git describe --tags `git rev-list --tags --max-count=1` | cut -c2-100)
-            docker build -t ${DOCKER_REPOSITORY}:${VERSION} .
+            docker build -t ${DOCKER_REPOSITORY}:${VERSION} -t ${DOCKER_REPOSITORY}:latest .
             docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
             docker push ${DOCKER_REPOSITORY}:${VERSION}
+            docker push ${DOCKER_REPOSITORY}:latest
 
 workflows:
   version: 2


### PR DESCRIPTION
Impact: **minor**
Type: **feature**

## Issue

"Latest" image tag is not currently being added to newly build images.

## Solution

Updated the CircleCI build config so that the "latest" tag is also added to each new docker image.
