### PR TITLE
Adds projectType to package.json (used to auto detect project type in CLI)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Admin interface to manage Mailchimp Open Commerce Stores",
   "version": "4.0.0-beta.20",
   "main": "main.js",
+  "reactionProjectType": "admin-meteor",
   "release": {
     "branches": [
       {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Admin interface to manage Mailchimp Open Commerce Stores",
   "version": "4.0.0-beta.20",
   "main": "main.js",
-  "reactionProjectType": "admin-meteor",
+  "projectType": "admin-meteor",
   "release": {
     "branches": [
       {


### PR DESCRIPTION
Signed-off-by: Sujith <sujith@merchstack.com>

Resolves reactioncommerce/cli#25
Impact: **minor**
Type: **feature**

## Issue

A new property "projectType": "admin-meteor" is required by the CLI to autoDetect the projectType when the user has not provided it as an argument.

## Solution

Added a new property to package.json which would identify the project type.
"projectType": "admin-meteor"
While issuing 'develop' command, we check if the projectType is provided by user as args and use it if present. Else we check for the newly introduced projectType property in package.json. If not found or if invalid, we throw error and exit.

## Breaking changes
None.

## Testing
Tested both cases of executing develop command with and without projectType argument - pass
Tested case where there is no projectType entry in package.json - pass
Tested case where there is invalid projectType entry in package.json - pass
